### PR TITLE
WAC-31 Stop using deprecated CKAN postgres image

### DIFF
--- a/roles/ckan/templates/kubernetes/db.yaml
+++ b/roles/ckan/templates/kubernetes/db.yaml
@@ -45,7 +45,9 @@ spec:
               value: /var/lib/postgresql/data/db
             - name: POSTGRES_PASSWORD
               value: "{{ ckan_postgres_password }}"
-          image: ckan/postgresql
+            - name: POSTGRES_USER
+              value: "ckan"
+          image: "{{ ckan_db_image }}"
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
## Description

Copy change from https://github.com/fjelltopp/fjelltopp-infrastructure/commit/7f2808ee9c86f0da62db68eb45d9697da980750b which was merged after this repo was forked.

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
