### PR TITLE
build: add release workflow to GH actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
       # (bump:major,bump:minor,bump:patch)
       - id: bumpr
         uses: haya14busa/action-bumpr@v1
-
       - name: Tag on GH
         uses: ncipollo/release-action@v1.14.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      
       # Bump version on merging Pull Requests with specific labels.
       # (bump:major,bump:minor,bump:patch)
       - id: bumpr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       # Bump version on merging Pull Requests with specific labels.
       # (bump:major,bump:minor,bump:patch)
       - id: bumpr
         uses: haya14busa/action-bumpr@v1
+        with:
+          default_bump_level: patch
+          
       - name: Tag on GH
         uses: ncipollo/release-action@v1.14.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: release
+on:
+  push:
+    branches:
+      - master
+      - releases
+    tags-ignore:
+      - "**"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Bump version on merging Pull Requests with specific labels.
+      # (bump:major,bump:minor,bump:patch)
+      - id: bumpr
+        uses: haya14busa/action-bumpr@v1
+
+      - name: Tag on GH
+        uses: ncipollo/release-action@v1.14.0
+        with:
+          tag: ${{ steps.bumpr.outputs.next_version }}
+          name: Release ${{ steps.bumpr.outputs.next_version }}
+          generateReleaseNotes: true
+          commit: ${{ vars.GITHUB_SHA }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - releases
     tags-ignore:
       - "**"
 


### PR DESCRIPTION
## Description

Automatically bump the version (using semver) and publish a tag & GH release on PR merge.

Default is `patch`.

Labels are: `bump:patch`, `bump:minor`, `bump:major`
and should be used in line with:

```
MAJOR version when you make incompatible API changes
MINOR version when you add functionality in a backward compatible manner
PATCH version when you make backward compatible bug fixes
```

Only apply one label, anything else is undefined behaviour!

- [x] I have rebased this branch with master.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
