### PR TITLE
WAC-7 Replace default group vars so that CKAN deploys

### DIFF
--- a/group_vars/all/all.yml
+++ b/group_vars/all/all.yml
@@ -51,7 +51,7 @@ ckan_fqdn: "ckan.minikube"
 ckan_site_url: "http://{{ ckan_fqdn }}"
 ckan_image: "ghcr.io/fjelltopp/fjelltopp-base-images/ckan"
 ckan_image_tag: "2.9.8"
-ckan_db_image: "ckan/postgresql"
+ckan_db_image: "postgres"
 
 # ckan_ds_ro_pass: "123456789"
 # ckan_ds_rw_pass: "123456789"


### PR DESCRIPTION
## Description

This puts back default group vars needed to successfully deploy ckan locally. 

Would be good to cross check with @cooper667 - several lines from fjelltopp-infrastructure group_vars/all had been removed or commented out, and I'm not sure who had done that or why.  Perhaps it was just because they looked like secrets and we were nervous about committing to a public repo?  The secrets are just used in development environments and so are not sensitive, they should all be overridden in cloud environments... though now I think about it, I wonder how sure we can be that we have not forgotten to override one of them?  Maybe we should create an ongoing ticket to address this?

Keen to understand that before we merge. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
