### PR TITLE
WAC-2 Rebuild solr index when bootstrapping CKAN.

### DIFF
--- a/roles/ckan/templates/ckan/ckan_bootstrap.sh
+++ b/roles/ckan/templates/ckan/ckan_bootstrap.sh
@@ -14,4 +14,6 @@ echo "make admin superuser"
 ckan -c "$CONFIG" sysadmin add admin
 echo "Set datastore permissions"
 ckan -c "$CONFIG" datastore set-permissions | psql "${CKAN_SQLALCHEMY_URL}"
+echo "Build search index"
+ckan -c "$CONFIG" search-index rebuild
 echo bootstrap finished


### PR DESCRIPTION
Quick fix to ensure that everything in the database is recognised by Solr when starting up CKAN locally. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
