### PR TITLE
WRC5: Fix incorrect aws config

### DIFF
--- a/roles/setup-eks/templates/eks_secrets_access_policy.json
+++ b/roles/setup-eks/templates/eks_secrets_access_policy.json
@@ -36,8 +36,8 @@
                 "secretsmanager:ListSecretVersionIds"
             ],
             "Resource": [
-                "arn:aws:secretsmanager:eu-west-1:494130958572:secret:eks*",
-                "arn:aws:secretsmanager:eu-west-1:494130958572:secret:{{ projectname }}*"
+                "arn:aws:secretsmanager:eu-west-1:{{ aws_account_id }}:secret:eks*",
+                "arn:aws:secretsmanager:eu-west-1:{{ aws_account_id }}:secret:{{ projectname }}*"
             ]
         }
     ]


### PR DESCRIPTION
We discovered that ansible was fed hardcoded aws_account_id. It is now changed to use the correct variable.