### PR TITLE
WAC-34 Install ckanext googleanalytics

### DIFF
--- a/roles/ckan/templates/ckan/ckan_production.ini
+++ b/roles/ckan/templates/ckan/ckan_production.ini
@@ -126,6 +126,18 @@ ckanext.emailasusername.require_user_email_input_confirmation = False
 #               same origin policy
 ckan.plugins = {{ ckan_plugins }}
 
+
+## Google analytics settings
+googleanalytics.measurement_id = G-MCS01BTG6Q
+googleanalytics.property_id = 448344994
+googleanalytics.account = who.afro.ckan
+googleanalytics.username = who.afro.ckan@gmail.com
+googleanalytics.show_downloads = true
+# The following setting has to do with making sure resource downloads
+# are router to the proper handler after going throught analytics.
+# Since this functionality is not working well yet, it is disabled.
+# googleanalytics.download_handler = ckanext.blob_storage.blueprints:download
+
 ckanext.blob_storage.storage_service_url={{ giftless_url }}
 ckanext.blob_storage.use_scheming_file_uploader=True
 
@@ -229,18 +241,6 @@ smtp.password = {{ ckan_smtp_password }}
 
 ## Background Job Settings
 ckan.jobs.timeout = 180
-
-
-## Google analytics settings
-googleanalytics.measurement_id = G-MCS01BTG6Q
-googleanalytics.property_id = 448344994
-googleanalytics.account = who.afro.ckan
-googleanalytics.username = who.afro.ckan@gmail.com
-googleanalytics.show_downloads = true
-# The following setting has to do with making sure resource downloads
-# are router to the proper handler after going throught analytics.
-# Since this functionality is not working well yet, it is disabled.
-# googleanalytics.download_handler = ckanext.blob_storage.blueprints:download
 
 # Additional CKAN settings for extensions, configurable via group_vars
 {{ ckan_extras }}

--- a/roles/ckan/templates/ckan/ckan_production.ini
+++ b/roles/ckan/templates/ckan/ckan_production.ini
@@ -230,6 +230,18 @@ smtp.password = {{ ckan_smtp_password }}
 ## Background Job Settings
 ckan.jobs.timeout = 180
 
+
+## Google analytics settings
+googleanalytics.measurement_id = G-MCS01BTG6Q
+googleanalytics.property_id = 448344994
+googleanalytics.account = who.afro.ckan
+googleanalytics.username = who.afro.ckan@gmail.com
+googleanalytics.show_downloads = true
+# The following setting has to do with making sure resource downloads
+# are router to the proper handler after going throught analytics.
+# Since this functionality is not working well yet, it is disabled.
+# googleanalytics.download_handler = ckanext.blob_storage.blueprints:download
+
 # Additional CKAN settings for extensions, configurable via group_vars
 {{ ckan_extras }}
 

--- a/roles/ckan/templates/kubernetes/ckan.yaml
+++ b/roles/ckan/templates/kubernetes/ckan.yaml
@@ -23,6 +23,15 @@ type: Opaque
 {% endif %}
 
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: google-analytics-credentials
+data:
+  google_analytics_credentials.json: "{{ google_analytics_credentials | b64encode }}"
+type: Opaque
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -95,11 +104,11 @@ spec:
               export HOME=/usr/lib/ckan/;
               pipenv --version;
               pipenv sync --dev;
-              ./bootstrap.sh;
               rm -rf venv;
               ln -s .minikubevenv/ckan-ALitmJXH venv;
               ls -la /usr/lib/ckan/venv/;
-              sh /tmp/ckan_bootstrap.sh
+              sh /tmp/ckan_bootstrap.sh;
+              ./bootstrap.sh
 
           volumeMounts:
             - mountPath: /usr/lib/ckan
@@ -115,6 +124,10 @@ spec:
               name: ckan-storage
             - mountPath: /var/lib/ckan/webassets
               name: ckan-webassets
+            - mountPath: /tmp/google_analytics_credentials.json
+              name: google-analytics-credentials
+              readOnly: true
+              subPath: google_analytics_credentials.json
 
 
 {% endif %}
@@ -220,6 +233,9 @@ spec:
         - secret:
             secretName: ckan-bootstrap
           name: ckan-bootstrap
+        - secret:
+            secretName: google-analytics-credentials
+          name: google-analytics-credentials
 {% endif %}
         - name: ckan-configs
           secret:

--- a/roles/ckan/templates/kubernetes/ckan.yaml
+++ b/roles/ckan/templates/kubernetes/ckan.yaml
@@ -28,7 +28,7 @@ kind: Secret
 metadata:
   name: google-analytics-credentials
 data:
-  google_analytics_credentials.json: "{{ google_analytics_credentials | b64encode }}"
+  google_analytics_credentials.json: "{{ google_analytics_credentials | to_json | b64encode }}"
 type: Opaque
 
 ---

--- a/roles/ckan/templates/kubernetes/ckan.yaml
+++ b/roles/ckan/templates/kubernetes/ckan.yaml
@@ -124,13 +124,12 @@ spec:
               name: ckan-storage
             - mountPath: /var/lib/ckan/webassets
               name: ckan-webassets
-            - mountPath: /tmp/google_analytics_credentials.json
+{% endif %}
+            - mountPath: {{ google_analytics_credentials_path }}
               name: google-analytics-credentials
               readOnly: true
               subPath: google_analytics_credentials.json
 
-
-{% endif %}
       containers:
         - env:
             - name: CKAN_DATAPUSHER_URL
@@ -233,13 +232,13 @@ spec:
         - secret:
             secretName: ckan-bootstrap
           name: ckan-bootstrap
-        - secret:
-            secretName: google-analytics-credentials
-          name: google-analytics-credentials
 {% endif %}
         - name: ckan-configs
           secret:
             secretName: ckan-configs
+        - name: google-analytics-credentials
+          secret:
+            secretName: google-analytics-credentials
 
 ---
 apiVersion: v1

--- a/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
+++ b/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
@@ -26,10 +26,11 @@ spec:
               - "curl -rl -X POST -H 'Authorization: {{ ckan_sysadmin_api_key }}' {{ ckan_site_url }}/api/action/send_email_notifications;
                  curl -rl -X POST -H 'Authorization: {{ ckan_sysadmin_api_key }}' {{ ckan_site_url }}/api/action/send_sms_notifications;
                  ckan -c /etc/ckan/production.ini googleanalytics load /tmp/google_analytics_credentials.json"
-          - mountPath: /tmp/google_analytics_credentials.json
-            name: google-analytics-credentials
-            readOnly: true
-            subPath: google_analytics_credentials.json
+          volumeMounts:
+            - mountPath: /tmp/google_analytics_credentials.json
+              name: google-analytics-credentials
+              readOnly: true
+              subPath: google_analytics_credentials.json
 
           restartPolicy: Never
           volumes:

--- a/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
+++ b/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
@@ -1,13 +1,4 @@
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: google-analytics-credentials
-data:
-  google_analytics_credentials.json: "{{ google_analytics_credentials | b64encode }}"
-type: Opaque
-
----
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
+++ b/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
@@ -24,16 +24,26 @@ spec:
             command: ['bash', '-c']
             args:
               - "curl -rl -X POST -H 'Authorization: {{ ckan_sysadmin_api_key }}' {{ ckan_site_url }}/api/action/send_email_notifications;
-                 curl -rl -X POST -H 'Authorization: {{ ckan_sysadmin_api_key }}' {{ ckan_site_url }}/api/action/send_sms_notifications;
-                 ckan -c /etc/ckan/production.ini googleanalytics load /tmp/google_analytics_credentials.json"
-          volumeMounts:
-            - mountPath: /tmp/google_analytics_credentials.json
-              name: google-analytics-credentials
-              readOnly: true
-              subPath: google_analytics_credentials.json
+                 curl -rl -X POST -H 'Authorization: {{ ckan_sysadmin_api_key }}' {{ ckan_site_url }}/api/action/send_sms_notifications"
 
           restartPolicy: Never
-          volumes:
-            - secret:
-                secretName: google-analytics-credentials
-              name: google-analytics-credentials
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ckan-googleanalytics-cronjob
+spec:
+  schedule: "0 */6 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: ckan-cronjob
+            image: {{ fjelltopp_base_image }}
+            command: ['bash', '-c']
+            args:
+              - "curl -rl -X POST -H 'Authorization: {{ ckan_sysadmin_api_key }}' --json '{\"credentials_path\": {{ google_analytics_credentials_path }} }' {{ ckan_site_url }}/api/action/download_package_stats"
+
+          restartPolicy: Never

--- a/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
+++ b/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
@@ -44,6 +44,6 @@ spec:
             image: {{ fjelltopp_base_image }}
             command: ['bash', '-c']
             args:
-              - "curl -rl -X POST -H 'Authorization: {{ ckan_sysadmin_api_key }}' --json '{\"credentials_path\": {{ google_analytics_credentials_path }} }' {{ ckan_site_url }}/api/action/download_package_stats"
+              - "curl -rl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d '{\"credentials_path\": \"{{ google_analytics_credentials_path }}\" }' {{ ckan_site_url }}/api/action/download_package_stats"
 
           restartPolicy: Never

--- a/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
+++ b/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
@@ -1,4 +1,13 @@
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: google-analytics-credentials
+data:
+  google_analytics_credentials.json: "{{ google_analytics_credentials | b64encode }}"
+type: Opaque
+
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -15,5 +24,15 @@ spec:
             command: ['bash', '-c']
             args:
               - "curl -rl -X POST -H 'Authorization: {{ ckan_sysadmin_api_key }}' {{ ckan_site_url }}/api/action/send_email_notifications;
-                curl -rl -X POST -H 'Authorization: {{ ckan_sysadmin_api_key }}' {{ ckan_site_url }}/api/action/send_sms_notifications"
+                 curl -rl -X POST -H 'Authorization: {{ ckan_sysadmin_api_key }}' {{ ckan_site_url }}/api/action/send_sms_notifications;
+                 ckan -c /etc/ckan/production.ini googleanalytics load /tmp/google_analytics_credentials.json"
+          - mountPath: /tmp/google_analytics_credentials.json
+            name: google-analytics-credentials
+            readOnly: true
+            subPath: google_analytics_credentials.json
+
           restartPolicy: Never
+          volumes:
+            - secret:
+                secretName: google-analytics-credentials
+              name: google-analytics-credentials


### PR DESCRIPTION
## Description
This PR modifies `production.ini` file by adding configuration options for the `ckanext-googleanalytics` extension.
It also mounts the Google service account credentials file that is used to pull data from Google Analytics.
Last, it creates a cronjob that runs every 6 hours to pull data from Google Analytics.

The ticket [WAC-34](https://fjelltopp.atlassian.net/browse/WAC-34) requires the changes made in this PR so that we can send and collect analytics from Google Analytics 4.

This PR relates to:
- [fjelltopp/fjelltopp-infrastructure#242](https://github.com/fjelltopp/fjelltopp-infrastructure/pull/242)

## Checklist

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".


[WAC-34]: https://fjelltopp.atlassian.net/browse/WAC-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ