### PR TITLE
WAC-105 Enabled blob_storage as download handler for googleanalytics

### DIFF
--- a/roles/ckan/templates/ckan/ckan_production.ini
+++ b/roles/ckan/templates/ckan/ckan_production.ini
@@ -133,9 +133,6 @@ googleanalytics.property_id = 448344994
 googleanalytics.account = who.afro.ckan
 googleanalytics.username = who.afro.ckan@gmail.com
 googleanalytics.show_downloads = true
-# The following setting has to do with making sure resource downloads
-# are router to the proper handler after going throught analytics.
-# Since this functionality is not working well yet, it is disabled.
 googleanalytics.download_handler = ckanext.blob_storage.blueprints:download
 
 ckanext.blob_storage.storage_service_url={{ giftless_url }}

--- a/roles/ckan/templates/ckan/ckan_production.ini
+++ b/roles/ckan/templates/ckan/ckan_production.ini
@@ -136,7 +136,7 @@ googleanalytics.show_downloads = true
 # The following setting has to do with making sure resource downloads
 # are router to the proper handler after going throught analytics.
 # Since this functionality is not working well yet, it is disabled.
-# googleanalytics.download_handler = ckanext.blob_storage.blueprints:download
+googleanalytics.download_handler = ckanext.blob_storage.blueprints:download
 
 ckanext.blob_storage.storage_service_url={{ giftless_url }}
 ckanext.blob_storage.use_scheming_file_uploader=True


### PR DESCRIPTION
## Description

The work in [WAC-34](https://fjelltopp.atlassian.net/browse/WAC-34)  requires that we specify the download handler to be used by ckanext-googleanalytics in `production.ini`.

The particular code that does this was commented.
This PR fixes that. Details can be found at [WAC-105](https://fjelltopp.atlassian.net/browse/WAC-105).

relates [fjelltopp/fjelltopp-ansible#16](https://github.com/fjelltopp/fjelltopp-ansible/pull/16)

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".


[WAC-34]: https://fjelltopp.atlassian.net/browse/WAC-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WAC-105]: https://fjelltopp.atlassian.net/browse/WAC-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ