### PR TITLE
WAC-106: Fix bug introduced by ckanext-googleanalytics work

### DIFF
--- a/group_vars/all/all.yml
+++ b/group_vars/all/all.yml
@@ -112,6 +112,26 @@ giftless_url: "http://{{ ckan_fqdn }}/giftless"
 giftless_image: "ghcr.io/fjelltopp/fjelltopp-base-images/giftless"
 giftless_version: "v0.4.0-fjelltopp"
 
+# Google analytics
+ckan_googleanalytics_enable: false
+ckan_googleanalytics_credentials: |-
+  {
+    "type": "",
+    "project_id": "",
+    "private_key_id": "",
+    "private_key": "{{ ckan_googleanalytics_private_key }}",
+    "client_email": "",
+    "client_id": "",
+    "auth_uri": "",
+    "token_uri": "",
+    "auth_provider_x509_cert_url": "",
+    "client_x509_cert_url": "",
+    "universe_domain": ""
+  }
+ckan_googleanalytics_credentials_path: "/tmp/google_analytics_credentials.json"
+ckan_googleanalytics_measurement_id: ""
+ckan_googleanalytics_property_id: ""
+
 # who.ini
 
 who_authenticators: |-

--- a/group_vars/all/all.yml
+++ b/group_vars/all/all.yml
@@ -129,8 +129,6 @@ ckan_googleanalytics_credentials: |-
     "universe_domain": ""
   }
 ckan_googleanalytics_credentials_path: "/tmp/google_analytics_credentials.json"
-ckan_googleanalytics_measurement_id: ""
-ckan_googleanalytics_property_id: ""
 
 # who.ini
 

--- a/roles/ckan/templates/ckan/ckan_production.ini
+++ b/roles/ckan/templates/ckan/ckan_production.ini
@@ -127,10 +127,10 @@ ckanext.emailasusername.require_user_email_input_confirmation = False
 ckan.plugins = {{ ckan_plugins }}
 
 
-{% if enable_google_analytics is defined and enable_google_analytics %}
+{% if ckan_googleanalytics_enable %}
 ## Google analytics settings
-googleanalytics.measurement_id = G-MCS01BTG6Q
-googleanalytics.property_id = 448344994
+googleanalytics.measurement_id = {{ ckan_googleanalytics_measurement_id }}
+googleanalytics.property_id = {{ ckan_googleanalytics_property_id }}
 googleanalytics.account = who.afro.ckan
 googleanalytics.username = who.afro.ckan@gmail.com
 googleanalytics.show_downloads = true

--- a/roles/ckan/templates/ckan/ckan_production.ini
+++ b/roles/ckan/templates/ckan/ckan_production.ini
@@ -127,16 +127,6 @@ ckanext.emailasusername.require_user_email_input_confirmation = False
 ckan.plugins = {{ ckan_plugins }}
 
 
-{% if ckan_googleanalytics_enable %}
-## Google analytics settings
-googleanalytics.measurement_id = {{ ckan_googleanalytics_measurement_id }}
-googleanalytics.property_id = {{ ckan_googleanalytics_property_id }}
-googleanalytics.account = who.afro.ckan
-googleanalytics.username = who.afro.ckan@gmail.com
-googleanalytics.show_downloads = true
-googleanalytics.download_handler = ckanext.blob_storage.blueprints:download
-{% endif %}
-
 ckanext.blob_storage.storage_service_url={{ giftless_url }}
 ckanext.blob_storage.use_scheming_file_uploader=True
 

--- a/roles/ckan/templates/ckan/ckan_production.ini
+++ b/roles/ckan/templates/ckan/ckan_production.ini
@@ -127,6 +127,7 @@ ckanext.emailasusername.require_user_email_input_confirmation = False
 ckan.plugins = {{ ckan_plugins }}
 
 
+{% if enable_google_analytics is defined and enable_google_analytics %}
 ## Google analytics settings
 googleanalytics.measurement_id = G-MCS01BTG6Q
 googleanalytics.property_id = 448344994
@@ -134,6 +135,7 @@ googleanalytics.account = who.afro.ckan
 googleanalytics.username = who.afro.ckan@gmail.com
 googleanalytics.show_downloads = true
 googleanalytics.download_handler = ckanext.blob_storage.blueprints:download
+{% endif %}
 
 ckanext.blob_storage.storage_service_url={{ giftless_url }}
 ckanext.blob_storage.use_scheming_file_uploader=True

--- a/roles/ckan/templates/kubernetes/ckan.yaml
+++ b/roles/ckan/templates/kubernetes/ckan.yaml
@@ -231,11 +231,6 @@ spec:
         - name: ckan-configs
           secret:
             secretName: ckan-configs
-{% if ckan_googleanalytics_enable %}
-        - name: ckan-configs
-          secret:
-            secretName: google-analytics-credentials
-{% endif %}
 
 ---
 apiVersion: v1

--- a/roles/ckan/templates/kubernetes/ckan.yaml
+++ b/roles/ckan/templates/kubernetes/ckan.yaml
@@ -22,6 +22,7 @@ data:
 type: Opaque
 {% endif %}
 
+{% if enable_google_analytics is defined and enable_google_analytics %}
 ---
 apiVersion: v1
 kind: Secret
@@ -30,6 +31,7 @@ metadata:
 data:
   google_analytics_credentials.json: "{{ google_analytics_credentials | to_json | b64encode }}"
 type: Opaque
+{% endif %}
 
 ---
 apiVersion: apps/v1
@@ -125,11 +127,12 @@ spec:
             - mountPath: /var/lib/ckan/webassets
               name: ckan-webassets
 {% endif %}
+{% if enable_google_analytics is defined and enable_google_analytics %}
             - mountPath: {{ google_analytics_credentials_path }}
               name: google-analytics-credentials
               readOnly: true
               subPath: google_analytics_credentials.json
-
+{% endif %}
       containers:
         - env:
             - name: CKAN_DATAPUSHER_URL
@@ -236,9 +239,11 @@ spec:
         - name: ckan-configs
           secret:
             secretName: ckan-configs
+{% if enable_google_analytics is defined and enable_google_analytics %}
         - name: google-analytics-credentials
           secret:
             secretName: google-analytics-credentials
+{% endif %}
 
 ---
 apiVersion: v1

--- a/roles/ckan/templates/kubernetes/ckan.yaml
+++ b/roles/ckan/templates/kubernetes/ckan.yaml
@@ -9,6 +9,9 @@ data:
   jwt-rs256.key.pub: "{{ ckan_jwt_public_key|string | b64encode  }}"
   ckan-uwsgi.ini: "{{ lookup('template', 'templates/ckan/ckan-uwsgi.ini') | b64encode }}"
   wsgi.py: "{{ lookup('template', 'templates/ckan/wsgi.py') | b64encode }}"
+{% if ckan_googleanalytics_enable %}
+  ckan_googleanalytics_credentials.json: "{{ ckan_googleanalytics_credentials | to_json | b64encode }}"
+{% endif %}
 type: Opaque
 
 {% if fjelltopp_env_type == 'local' %}
@@ -19,17 +22,6 @@ metadata:
   name: ckan-bootstrap
 data:
   ckan_bootstrap.sh: "{{ lookup('template', 'templates/ckan/ckan_bootstrap.sh') | b64encode }}"
-type: Opaque
-{% endif %}
-
-{% if enable_google_analytics is defined and enable_google_analytics %}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: google-analytics-credentials
-data:
-  google_analytics_credentials.json: "{{ google_analytics_credentials | to_json | b64encode }}"
 type: Opaque
 {% endif %}
 
@@ -127,11 +119,11 @@ spec:
             - mountPath: /var/lib/ckan/webassets
               name: ckan-webassets
 {% endif %}
-{% if enable_google_analytics is defined and enable_google_analytics %}
-            - mountPath: {{ google_analytics_credentials_path }}
-              name: google-analytics-credentials
+{% if ckan_googleanalytics_enable %}
+            - mountPath: {{ ckan_googleanalytics_credentials_path }}
+              name: ckan-configs
               readOnly: true
-              subPath: google_analytics_credentials.json
+              subPath: ckan_googleanalytics_credentials.json
 {% endif %}
       containers:
         - env:
@@ -239,8 +231,8 @@ spec:
         - name: ckan-configs
           secret:
             secretName: ckan-configs
-{% if enable_google_analytics is defined and enable_google_analytics %}
-        - name: google-analytics-credentials
+{% if ckan_googleanalytics_enable %}
+        - name: ckan-configs
           secret:
             secretName: google-analytics-credentials
 {% endif %}

--- a/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
+++ b/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
@@ -19,6 +19,7 @@ spec:
 
           restartPolicy: Never
 
+{% if enable_google_analytics is defined and enable_google_analytics %}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -38,3 +39,4 @@ spec:
               - "curl -rl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d '{\"credentials_path\": \"{{ google_analytics_credentials_path }}\" }' {{ ckan_site_url }}/api/action/download_package_stats"
 
           restartPolicy: Never
+{% endif %}

--- a/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
+++ b/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
@@ -19,7 +19,7 @@ spec:
 
           restartPolicy: Never
 
-{% if enable_google_analytics is defined and enable_google_analytics %}
+{% if ckan_googleanalytics_enable %}
 ---
 apiVersion: batch/v1
 kind: CronJob

--- a/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
+++ b/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
@@ -36,7 +36,7 @@ spec:
             image: {{ fjelltopp_base_image }}
             command: ['bash', '-c']
             args:
-              - "curl -rl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d '{\"credentials_path\": \"{{ google_analytics_credentials_path }}\" }' {{ ckan_site_url }}/api/action/download_package_stats"
+              - "curl -rl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d '{\"credentials_path\": \"{{ ckan_googleanalytics_credentials_path }}\" }' {{ ckan_site_url }}/api/action/download_package_stats"
 
           restartPolicy: Never
 {% endif %}


### PR DESCRIPTION
## Description

The work to have Google analytics enabled did not, unfortunately, consider that some projects will not need
this functionality. Consequently a lot of projects are failing right now.

This PR, corresponding to [WAC-106](https://fjelltopp.atlassian.net/browse/WAC-106) fixes that by doing the following:
- It introduces a new variable `enable_google_analytics` which when either undefined or defined and set to `false` will decide whether to enable or disable Google analytics.
- It wraps the sections that Google analytics needs in a conditional that depends on `enable_google_analytics` so features required for Google analytics are enabled or disabled:
  - In `roles/ckan/templates/ckan/ckan_production.ini`: conditionally configure `ckanext-googleanalytics`.
  - In `roles/ckan/templates/kubernetes/ckan.yaml`: conditionally mount the path containing the Google analytics service account credentials.
  - In `roles/ckan/templates/kubernetes/ckan_cronjob.yaml`: conditionally create a cronjob to periodically pull data from Google analytics.

This PR is related to:
- [fjelltopp/fjelltopp-ansible#16](https://github.com/fjelltopp/fjelltopp-ansible/pull/16#pullrequestreview-2196419691)

## Documentation

I have documented the need to properly set the Google analytics Ansible variables for it to work
at [Enabling Google Analytics in a project](https://fjelltopp.atlassian.net/wiki/spaces/TKB/pages/368541701/Enabling+Google+Analytics+in+a+project).

## Checklist

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [x] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".


[WAC-106]: https://fjelltopp.atlassian.net/browse/WAC-106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ