### PR TITLE
WAC-106 Default variable value for ckan_googleanalytics_private_key

### DIFF
--- a/group_vars/all/all.yml
+++ b/group_vars/all/all.yml
@@ -115,6 +115,7 @@ giftless_version: "v0.4.0-fjelltopp"
 
 # Google analytics
 ckan_googleanalytics_enable: false
+ckan_googleanalytics_private_key: ""
 ckan_googleanalytics_credentials: |-
   {
     "type": "",


### PR DESCRIPTION
## Description
Very tiny issue that we didn't catch.  The default value of `ckan_googleanalytics_credentials` references a variable `ckan_googleanalytics_private_key`, in order to clearly indicate that the secret value should be held in a seperate variable.   However this separate variable did not have any default value set. This was causing WRC CKAN deployments to fail. I have just set the default variable value to an empty string. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
