### PR TITLE
WAC-34 Deploy Google Analytics extension to Azure cloud

### DIFF
--- a/group_vars/all/all.yml
+++ b/group_vars/all/all.yml
@@ -115,6 +115,7 @@ giftless_version: "v0.4.0-fjelltopp"
 
 # Google analytics
 ckan_googleanalytics_enable: false
+ckan_googleanalytics_private_key: ""
 ckan_googleanalytics_credentials: |-
   {
     "type": "",

--- a/group_vars/all/all.yml
+++ b/group_vars/all/all.yml
@@ -130,10 +130,8 @@ ckan_googleanalytics_credentials: |-
     "client_x509_cert_url": "",
     "universe_domain": ""
   }
-ckan_googleanalytics_credentials_path: "/tmp/google_analytics_credentials.json"
 
 # who.ini
-
 who_authenticators: |-
   [authenticators]
   plugins =

--- a/roles/ckan/tasks/azure-secrets.yml
+++ b/roles/ckan/tasks/azure-secrets.yml
@@ -11,6 +11,7 @@
       azure_db_admin_password: azure-db-admin-password
       ckan_superuser_password: ckan-superuser-password
       ckan_admin_api_token: ckan-api-key-datapusher # This should be set manually in the KeyVault when required
+      ckan_googleanalytics_private_key: ckan-googleanalytics-private-key # This should be set manually in the KeyVault when required
 
 - name: Init missing secrets
   block:

--- a/roles/ckan/templates/kubernetes/ckan.yaml
+++ b/roles/ckan/templates/kubernetes/ckan.yaml
@@ -119,12 +119,6 @@ spec:
             - mountPath: /var/lib/ckan/webassets
               name: ckan-webassets
 {% endif %}
-{% if ckan_googleanalytics_enable %}
-            - mountPath: {{ ckan_googleanalytics_credentials_path }}
-              name: ckan-configs
-              readOnly: true
-              subPath: ckan_googleanalytics_credentials.json
-{% endif %}
       containers:
         - env:
             - name: CKAN_DATAPUSHER_URL

--- a/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
+++ b/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
@@ -36,7 +36,7 @@ spec:
             image: {{ fjelltopp_base_image }}
             command: ['bash', '-c']
             args:
-              - "curl -rl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d '{\"credentials_path\": \"{{ ckan_googleanalytics_credentials_path }}\" }' {{ ckan_site_url }}/api/action/download_package_stats"
+              - "curl -rl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d '{\"credentials_path\": \"/etc/ckan/google_analytics_credentials.json\" }' {{ ckan_site_url }}/api/action/download_package_stats"
 
           restartPolicy: Never
 {% endif %}


### PR DESCRIPTION
## Description
Deploying the google analytics extension to Azure cloud requires some ansible changes and cleanup.

- We need to add a default private key value.
- We need to add the private key to the list of Azure key vault secrets.
- Since we are loading the config in the standard way along with other CKAN configs to /etc/ckan I figured that we had no need to pre specify the credentials location in a seperate ansible variable.  This can just be fixed in our infrastructure to `/etc/ckan/google_analytics_credentials.json`

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
