### PR TITLE
WAC-34 Remove to_json filter

### DIFF
--- a/roles/ckan/templates/kubernetes/ckan.yaml
+++ b/roles/ckan/templates/kubernetes/ckan.yaml
@@ -10,7 +10,7 @@ data:
   ckan-uwsgi.ini: "{{ lookup('template', 'templates/ckan/ckan-uwsgi.ini') | b64encode }}"
   wsgi.py: "{{ lookup('template', 'templates/ckan/wsgi.py') | b64encode }}"
 {% if ckan_googleanalytics_enable %}
-  google_analytics_credentials.json: "{{ ckan_googleanalytics_credentials | to_json | b64encode }}"
+  google_analytics_credentials.json: "{{ ckan_googleanalytics_credentials | b64encode }}"
 {% endif %}
 type: Opaque
 


### PR DESCRIPTION
## Description

to_json is only needed if the contents of `ckan_googleanalytics_credentials` is a jinja template with jinja syntax. 

This filter seems to cause problems if the contents is plain string. It needs to be removed for the contents to be written correctly as a json file. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
