### PR TITLE
fix: ReadWriteMany for vols on AWS

### DIFF
--- a/roles/ckan/templates/kubernetes/ckan_volumes.yaml
+++ b/roles/ckan/templates/kubernetes/ckan_volumes.yaml
@@ -26,7 +26,7 @@ spec:
   storageClassName: "{{ storage_class_name }}"
 {% endif %}  
   accessModes:
-    - "{{ (fjelltopp_cloud_provider == 'azure') | ternary('ReadWriteMany', 'ReadWriteOnce') }}" # Azure supports ReadWriteMany and it's required for rolling deployments
+    - ReadWriteMany
   resources:
     requests:
       storage: "{{ (fjelltopp_cloud_provider == 'azure') | ternary('1Gi', '100Mi') }}"
@@ -61,7 +61,7 @@ spec:
   storageClassName: "{{ storage_class_name }}"
 {% endif %} 
   accessModes:
-    - "{{ (fjelltopp_cloud_provider == 'azure') | ternary('ReadWriteMany', 'ReadWriteOnce') }}"
+    - ReadWriteMany
   resources:
     requests:
       storage: "{{ (fjelltopp_cloud_provider == 'azure') | ternary('1Gi', '100Mi') }}"
@@ -82,7 +82,7 @@ spec:
     name: localckan
     namespace: {{ application_namespace }}
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   capacity:
     storage: 20Gi
   hostPath:

--- a/roles/ckan/templates/kubernetes/ckan_volumes.yaml
+++ b/roles/ckan/templates/kubernetes/ckan_volumes.yaml
@@ -29,7 +29,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: "{{ (fjelltopp_cloud_provider == 'azure') | ternary('1Gi', '100Mi') }}"
+      storage: 1Gi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -43,10 +43,10 @@ spec:
   storageClassName: "{{ storage_class_name }}"
 {% endif %}  
   accessModes:
-    - "{{ (fjelltopp_cloud_provider == 'azure') | ternary('ReadWriteMany', 'ReadWriteOnce') }}" 
+    - ReadWriteMany
   resources:
     requests:
-      storage: "{{ (fjelltopp_cloud_provider == 'azure') | ternary('1Gi', '100Mi') }}"
+      storage: 1Gi
 
 ---
 apiVersion: v1
@@ -61,7 +61,7 @@ spec:
   storageClassName: "{{ storage_class_name }}"
 {% endif %} 
   accessModes:
-    - ReadWriteMany
+    - "{{ (fjelltopp_cloud_provider == 'azure') | ternary('ReadWriteMany', 'ReadWriteOnce') }}"
   resources:
     requests:
       storage: "{{ (fjelltopp_cloud_provider == 'azure') | ternary('1Gi', '100Mi') }}"


### PR DESCRIPTION
## Description

When updating the K8S Volumes file, it looked like AWS was using ReadWriteOnce as the access mode (https://github.com/fjelltopp/fjelltopp-ansible/pull/25/files#diff-c333809702955a63a055989c2d391c5118d71ed085cc427500a375d55f9e5f57L12)

When deploying Zambia, @ChasNelson1990 gets:

```
"Failure","message":"PersistentVolumeClaim \"ckan-storage\" is invalid: [spec: Forbidden: spec is immutable after creation except resources.requests and volumeAttributesClassName for bound claims
```
```bash
-     AccessModes: []core.PersistentVolumeAccessMode{\"ReadWriteMany\"},
+     AccessModes: []core.PersistentVolumeAccessMode{\"ReadWriteOnce\"},
```

soooo it looks like the deployed infra has ReadWriteMany? Can be confirmed by getting the Volumes with kubectl

We should also double check the storage size is correct. If this differs across current AWS deploys, we can make it a var and put in the relevant infra files

## Testing (delete if not applicable)

Hopefully we can try this PR on an AWS Staging before merging?

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
