### PR TITLE
[#267] Add environment variable that indicates whether Google analytics is enabled or not

### DIFF
--- a/roles/ckan/templates/kubernetes/ckan.yaml
+++ b/roles/ckan/templates/kubernetes/ckan.yaml
@@ -87,7 +87,7 @@ spec:
             - name: XDG_CACHE_HOME
               value: "/usr/lib/ckan/.minikubevenv/cache"
 {% if ckan_googleanalytics_enable %}
-            - name: CKAN_GOOGLEANALYTICS_ENABLE
+            - name: CKAN_GOOGLEANALYTICS_ENABLED
               value: "1"
 {% endif %}
 

--- a/roles/ckan/templates/kubernetes/ckan.yaml
+++ b/roles/ckan/templates/kubernetes/ckan.yaml
@@ -86,10 +86,8 @@ spec:
               value: "/usr/lib/ckan/.minikubevenv"
             - name: XDG_CACHE_HOME
               value: "/usr/lib/ckan/.minikubevenv/cache"
-{% if ckan_googleanalytics_enable %}
             - name: CKAN_GOOGLEANALYTICS_ENABLED
-              value: "1"
-{% endif %}
+              value: "{{ ckan_googleanalytics_enable }}"
 
           image: {{ ckan_image }}:{{ ckan_image_tag }}
           imagePullPolicy: IfNotPresent

--- a/roles/ckan/templates/kubernetes/ckan.yaml
+++ b/roles/ckan/templates/kubernetes/ckan.yaml
@@ -147,6 +147,8 @@ spec:
               value: "{{ ckan_postgres_password }}"
             - name: PIPENV_DONT_LOAD_ENV
               value: "1"
+            - name: CKAN_GOOGLEANALYTICS_ENABLED
+              value: "{{ ckan_googleanalytics_enable }}"
 {% if fjelltopp_cloud_provider != 'azure' %}
             - name: AWS_DEFAULT_REGION
               value: "{{ aws_region }}"

--- a/roles/ckan/templates/kubernetes/ckan.yaml
+++ b/roles/ckan/templates/kubernetes/ckan.yaml
@@ -86,6 +86,10 @@ spec:
               value: "/usr/lib/ckan/.minikubevenv"
             - name: XDG_CACHE_HOME
               value: "/usr/lib/ckan/.minikubevenv/cache"
+{% if ckan_googleanalytics_enable %}
+            - name: CKAN_GOOGLEANALYTICS_ENABLE
+              value: "1"
+{% endif %}
 
           image: {{ ckan_image }}:{{ ckan_image_tag }}
           imagePullPolicy: IfNotPresent

--- a/roles/minikube-setup/tasks/main.yml
+++ b/roles/minikube-setup/tasks/main.yml
@@ -25,4 +25,3 @@
     line: "{{ cluster_ip }} {{ app_fqdn }}"
     state: present
     backup: yes
-  become: true


### PR DESCRIPTION
## Description
This PR, born from issue [fjelltopp-infrastructure#267](https://github.com/fjelltopp/fjelltopp-infrastructure/issues/267),
adds a new environment variable that allows applications to detect whether the Google analytics extension is enabled or not.

## Environment Changes
Yes, a new environment variable has been created as part of this PR: the `CKAN_GOOGLEANALYTICS_ENABLED` variable.
No documentation (README or Confluence) has been updated/created because:
- All the relevant README (in this repository or `fjelltopp-infrastructure`) contain nothing related to environment variables,
- There is no Confluence documentation I could find that is related to environment variables.

But this definitely needs to be documented somewhere.

## Checklist
- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
