### PR TITLE
infra249 fix version of compatible aws.amazon collection

### DIFF
--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -22,3 +22,6 @@ collections:
 - name: community.postgresql
   accept_hostkey: true
   version: 3.4.1
+- name: amazon.aws
+  accept_hostkey: true
+  version: 5.0.0


### PR DESCRIPTION
An old compatible version of amazon.aws collection that we didn't have specified. It was resulting in a bug coming recently on fresh ansible setups where the latest version of this collection is not compatible with our stack.

ultimately all collections need to be updated, but this will fix the breaking

Closing https://github.com/fjelltopp/fjelltopp-infrastructure/issues/249