### PR TITLE
Use fixed version of postgres image.

### DIFF
--- a/group_vars/all/all.yml
+++ b/group_vars/all/all.yml
@@ -53,7 +53,7 @@ ckan_fqdn: "ckan.minikube"
 ckan_site_url: "http://{{ ckan_fqdn }}"
 ckan_image: "ghcr.io/fjelltopp/fjelltopp-base-images/ckan"
 ckan_image_tag: "2.9.8"
-ckan_db_image: "postgres"
+ckan_db_image: "postgres:15"
 
 # ckan_ds_ro_pass: "123456789"
 # ckan_ds_rw_pass: "123456789"

--- a/roles/ckan/templates/kubernetes/db.yaml
+++ b/roles/ckan/templates/kubernetes/db.yaml
@@ -48,6 +48,8 @@ spec:
               value: "{{ ckan_postgres_password }}"
             - name: POSTGRES_USER
               value: "ckan"
+            - name: POSTGRES_HOST_AUTH_METHOD
+              value: md5
           image: "{{ ckan_db_image }}"
           livenessProbe:
             exec:


### PR DESCRIPTION
[Fix postgres image used for db pod to version 15](https://github.com/fjelltopp/fjelltopp-infrastructure/issues/276)

## Description

- Set up variable postgres host auth method
- Use fixed version of postgres container (15, this is 15.8-bookworm right now, if we want to be more precise this could be alligned)

relates fjelltopp/fjelltopp-infrastructure#276 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
