### PR TITLE
Use cookie session storage whilst Redis errors exist

### DIFF
--- a/roles/ckan/templates/ckan/ckan_production.ini
+++ b/roles/ckan/templates/ckan/ckan_production.ini
@@ -38,10 +38,12 @@ beaker.session.timeout = 86400
 beaker.session.secret = {{ ckan_beaker_secret }}
 
 ## CKAN >=2.11 Session settings
-SESSION_TYPE = redis
-SESSION_COOKIE_NAME = ckan
-SESSION_PERMANENT = true 
-PERMANENT_SESSION_LIFETIME = 86400
+## Using default cookie session storage until this issue is resolved:
+## https://github.com/ckan/ckan/issues/8547
+## SESSION_TYPE = redis
+## SESSION_COOKIE_NAME = ckan
+## SESSION_PERMANENT = true 
+## PERMANENT_SESSION_LIFETIME = 86400
 # The secret token that is used for session management and other security related tasks as well
 SECRET_KEY = {{ ckan_secret_key }}
 


### PR DESCRIPTION
## Description

Commenting out the redis session storage configurations until Redis session storage is fixed for CKAN 2.11 . 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
