### PR TITLE
wrc141 Disable giftless debug

### DIFF
--- a/group_vars/all/all.yml
+++ b/group_vars/all/all.yml
@@ -112,7 +112,7 @@ use_giftless: false
 giftless_url: "http://{{ ckan_fqdn }}/giftless"
 giftless_image: "ghcr.io/fjelltopp/fjelltopp-base-images/giftless"
 giftless_version: "v0.4.0-fjelltopp"
-giftless_debug: "0"
+giftless_debug: "false" #set to literal "true" to enable
 
 # Google analytics
 ckan_googleanalytics_enable: false

--- a/group_vars/all/all.yml
+++ b/group_vars/all/all.yml
@@ -112,6 +112,7 @@ use_giftless: false
 giftless_url: "http://{{ ckan_fqdn }}/giftless"
 giftless_image: "ghcr.io/fjelltopp/fjelltopp-base-images/giftless"
 giftless_version: "v0.4.0-fjelltopp"
+giftless_debug: "0"
 
 # Google analytics
 ckan_googleanalytics_enable: false

--- a/roles/ckan/templates/kubernetes/giftless.yaml
+++ b/roles/ckan/templates/kubernetes/giftless.yaml
@@ -19,7 +19,7 @@ type: Opaque
 ---
 apiVersion: apps/v1
 kind: Deployment
-metadata: 
+metadata:
   name: giftless
   annotations:
     reloader.stakater.com/auto: "true"
@@ -29,11 +29,11 @@ spec:
   strategy:
     type: Recreate
   selector:
-    matchLabels: 
+    matchLabels:
       app: giftless
   template:
     metadata:
-      labels: 
+      labels:
         app: giftless
     spec:
       containers:
@@ -52,7 +52,7 @@ spec:
         - 0.0.0.0:5001
         env:
         - name: GIFTLESS_DEBUG
-          value: "1"
+          value: {{ giftless_debug }}
         - name: GIFTLESS_CONFIG_FILE
           value: /app/giftless.yaml
         image: "{{ giftless_image }}:{{ giftless_version }}"
@@ -80,7 +80,7 @@ spec:
 ---
 apiVersion: v1
 kind: Service
-metadata: 
+metadata:
   name: giftless
 {% if fjelltopp_env_type != 'local' and giftless_s3_bucket is defined %}
   annotations:
@@ -88,7 +88,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ certificate_acm.certificates[0].certificate_arn }}
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "giftless-http"
 {% endif %}
-{% if giftless_azure_blob_string is defined %}      
+{% if giftless_azure_blob_string is defined %}
   annotations:
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
     service.beta.kubernetes.io/azure-pls-create: "true"
@@ -98,13 +98,11 @@ metadata:
     service.beta.kubernetes.io/azure-pls-visibility: "*"
 {% endif %}
 spec:
-{% if giftless_azure_blob_string is defined %}     
+{% if giftless_azure_blob_string is defined %}
   type: LoadBalancer
 {% endif %}
   ports:
   - name: 'giftless-http'
     port: 5001
-  selector: 
+  selector:
     app: giftless
-
-

--- a/roles/ckan/templates/kubernetes/giftless.yaml
+++ b/roles/ckan/templates/kubernetes/giftless.yaml
@@ -51,8 +51,13 @@ spec:
         - --http
         - 0.0.0.0:5001
         env:
+{% if giftless_debug == 'true' %}
         - name: GIFTLESS_DEBUG
-          value: "{{ giftless_debug }}"
+          value: "1"
+{% else %}
+        - name: GIFTLESS_DEBUG
+          value: ""
+{% endif %}
         - name: GIFTLESS_CONFIG_FILE
           value: /app/giftless.yaml
         image: "{{ giftless_image }}:{{ giftless_version }}"

--- a/roles/ckan/templates/kubernetes/giftless.yaml
+++ b/roles/ckan/templates/kubernetes/giftless.yaml
@@ -52,7 +52,7 @@ spec:
         - 0.0.0.0:5001
         env:
         - name: GIFTLESS_DEBUG
-          value: {{ giftless_debug }}
+          value: "{{ giftless_debug }}"
         - name: GIFTLESS_CONFIG_FILE
           value: /app/giftless.yaml
         image: "{{ giftless_image }}:{{ giftless_version }}"


### PR DESCRIPTION
Turning off `DEBUG` logging in giftless by default.

Closes https://github.com/fjelltopp/fjelltopp-infrastructure/issues/299 and specifically https://github.com/fjelltopp/who-romania-ckan/issues/141 for Romania.

## Testing:
Logs are no more spawning private info 😮‍💨 
```
kubectl logs -n wrc-sbx -l app=giftless --tail=1000
*** Starting uWSGI 2.0.28 (64bit) on [Thu Nov 28 15:19:24 2024] ***
compiled with version: 12.2.0 on 14 November 2024 19:17:13
os: Linux-5.4.219-126.411.amzn2.x86_64 #1 SMP Wed Nov 2 17:44:17 UTC 2022
nodename: giftless-5b55496d8-bzvcs
machine: x86_64
clock source: unix
pcre jit disabled
detected number of CPU cores: 2
current working directory: /app
detected binary path: /usr/local/bin/uwsgi
your memory page size is 4096 bytes
detected max file descriptor number: 1048576
lock engine: pthread robust mutexes
thunder lock: disabled (you can enable it with --thunder-lock)
uWSGI http bound on 0.0.0.0:5001 fd 4
uwsgi socket 0 bound to TCP address 127.0.0.1:40275 (port auto-assigned) fd 3
Python version: 3.8.20 (default, Sep 27 2024, 06:05:23)  [GCC 12.2.0]
Python main interpreter initialized at 0x558c0e16e8f0
python threads support enabled
your server socket listen backlog is limited to 100 connections
your mercy for graceful operations on workers is 60 seconds
mapped 250128 bytes (244 KB) for 4 cores
*** Operational MODE: preforking+threaded ***
WSGI app 0 (mountpoint='') ready in 0 seconds on interpreter 0x558c0e16e8f0 pid: 1 (default app)
*** uWSGI is running in multiple interpreter mode ***
spawned uWSGI master process (pid: 1)
spawned uWSGI worker 1 (pid: 8, cores: 2)
spawned uWSGI worker 2 (pid: 10, cores: 2)
spawned uWSGI http 1 (pid: 11)
[pid: 10|app: 0|req: 1/1] 172.17.140.246 () {72 vars in 2350 bytes} [Thu Nov 28 15:20:22 2024] POST /rabbits/yet-another-external-xls/objects/batch => generated 126 bytes in 283 msecs (HTTP/1.1 200) 2 headers in 84 bytes (1 switches on core 0)
```