### PR TITLE
DMS-54 Changes needed to get DMS deploying to cloud again

### DIFF
--- a/roles/ckan/tasks/deploy.yml
+++ b/roles/ckan/tasks/deploy.yml
@@ -91,7 +91,7 @@
 
 - name: Setup database parameters
   set_fact:
-    ckan_postgres_password: "{{ lookup('aws_secret', application_namespace + '_rds_admin_pw' , region = aws_region ) }}"
+    ckan_rds_admin_pw: "{{ lookup('aws_secret', application_namespace + '_rds_admin_pw' , region = aws_region ) }}"
     ckan_ds_ro_pass: "{{ lookup('aws_secret', application_namespace + '_datastore_ro_dbuser_password' , region = aws_region ) }}"
     ckan_ds_rw_pass: "{{ lookup('aws_secret', application_namespace + '_datastore_dbuser_password' , region = aws_region ) }}"
     ckan_db_hostname: "{{ ckan_rds_info.instances[0].endpoint.address }}"

--- a/roles/ckan/tasks/deploy.yml
+++ b/roles/ckan/tasks/deploy.yml
@@ -73,10 +73,7 @@
   become: false
   with_items:
     - db.yaml
-  # FIP-3 TODO
-  # Commented out for now, as there's a hardcoded db name in ckan_bootstrap, fix requires a custom
-  # container image
-  # when: fjelltopp_env_type == 'local'
+  when: fjelltopp_env_type == 'local'
 
 - name: Check if DB is alive [local] (10 tries, 5sec interval)
   community.postgresql.postgresql_ping:

--- a/roles/ckan/templates/kubernetes/ckan_volumes.yaml
+++ b/roles/ckan/templates/kubernetes/ckan_volumes.yaml
@@ -13,6 +13,7 @@ mountOptions:
   - gid=900
 {% endif %}
 
+
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/roles/ckan/templates/kubernetes/ckandb_job.yaml
+++ b/roles/ckan/templates/kubernetes/ckandb_job.yaml
@@ -25,7 +25,7 @@ spec:
             - name: POSTGRES_USER
               value: "{{ rds_admin_username }}"
             - name: POSTGRES_PASSWORD
-              value: "{{ ckan_postgres_password }}"
+              value: "{{ ckan_rds_admin_pw }}"
 
           name: ckan-db-init
           image: postgres:13


### PR DESCRIPTION
## Description

This repository makes a couple of improvements to the cloud deploy process:

1. The db pod is redundant in the cloud, and only needed to satisfy a db check in the ckan-entrypoint.sh file.  We now override this file and can change it to check that actual RDS.  Merging this PR therefore depends on updating all other ckan projects' entrypoint.  The example PR for DMS is here: https://github.com/fjelltopp/dms/pull/73
2. The ckan postgres password variable was being overwritten with the admin postgres password. In projects implemented since [this change](https://github.com/fjelltopp/fjelltopp-infrastructure/commit/d7a16d4db33554758bd71895d9c9cd6be64c3774#diff-288598bca2cc0a8821691e61562f27be45580fcc88847de9fd389c885027557eR91-R98) was made (I believe just romania and zarr - but I'm not sure how Avenir is deploying successfully at the moment). The symptom of the problem is that the ENV_VAR  $CKAN_SQLALCHEMY_URL in the ckan pod, includes the RDS admin password retrieved from secret's manager.  This PR just avoids confusing the two passwords. 

---
@ChasNelson1990 @mixmixmix Regarding point 2, I believe (but may have missed something) that Romania and ZARR projects will want to:

1. Manually update the CKAN user in each cloud environment's RDS to use the correct password (which can be retrieved from the secrets manager - xxx_xxx_ckan_dbuser_password). 
2. Redeploy each cloud environment using the code change in this PR

Note that this may incur downtime in the period between updating the ckan db user, and redeploying the cloud environment. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
