### PR TITLE
Use ckan user to check local db

### DIFF
--- a/roles/ckan/tasks/deploy.yml
+++ b/roles/ckan/tasks/deploy.yml
@@ -10,7 +10,7 @@
 
 - set_fact:
     storageClassName: "efs-client"
-    
+
 - name: obtain ACM certficate info
   community.aws.aws_acm_info:
     aws_region: "{{ aws_region }}"
@@ -79,7 +79,7 @@
   community.postgresql.postgresql_ping:
     db: ckan
     login_host: "{{ ckan_fqdn }}"
-    login_user: "{{ rds_admin_username }}"
+    login_user: "ckan"
     login_password: "{{ ckan_postgres_password }}"
   when: (fjelltopp_env_type == 'local')
   register: db_ping_result


### PR DESCRIPTION
I am hardcoding the db check during local deployment to use the `ckan` user rather than the value of `{rds_admin_password}`.  The ckan user should exist in all our ckan projects and is hard coded in various places (such as db_init.sql). 

This PR relates to: https://github.com/fjelltopp/fjelltopp-infrastructure/pull/328 which removes the unnecessary declaration of rds_admin_password in local environments. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
