### PR TITLE
Fix notification cronjob

### DIFF
--- a/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
+++ b/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
@@ -15,7 +15,7 @@ spec:
             command: ['bash', '-c']
             args:
               - "curl -rl -X POST -H 'Authorization: {{ ckan_sysadmin_api_key }}' {{ ckan_site_url }}/api/action/send_email_notifications;
-                 curl -rl -X POST -H 'Authorization: {{ ckan_sysadmin_api_key }}' {{ ckan_site_url }}/api/action/send_sms_notifications"
+                 curl -rl -X POST -H 'Authorization: {{ ckan_sysadmin_api_key }}' {{ ckan_site_url }}/api/action/send_phone_notifications"
 
           restartPolicy: Never
 


### PR DESCRIPTION
## Description

The ckan_cronjob.yaml defines a cronjob that triggers notifications in dms. It does this by calling a ckan action once a day. The name of that action has changed now that it incorporates both sms and whatsapp notifications.  This PR simply updates the name. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The GitHub ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
