### PR TITLE
Notification cron job

### DIFF
--- a/roles/ckan/defaults/main.yml
+++ b/roles/ckan/defaults/main.yml
@@ -14,7 +14,7 @@ ckan_debug_enabled: "false"
 
 fjelltopp_base_image: "fjelltopp/ubuntu:base"
 
-ckan_sysadmin_api_key: dummyvalue
+ckan_admin_api_token: dummyvalue
 
 ckan_recaptcha_publickey: ""
 ckan_recaptcha_privatekey: ""

--- a/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
+++ b/roles/ckan/templates/kubernetes/ckan_cronjob.yaml
@@ -14,8 +14,8 @@ spec:
             image: {{ fjelltopp_base_image }}
             command: ['bash', '-c']
             args:
-              - "curl -rl -X POST -H 'Authorization: {{ ckan_sysadmin_api_key }}' {{ ckan_site_url }}/api/action/send_email_notifications;
-                 curl -rl -X POST -H 'Authorization: {{ ckan_sysadmin_api_key }}' {{ ckan_site_url }}/api/action/send_phone_notifications"
+              - "curl -rl -X POST -H 'Authorization: {{ ckan_admin_api_token }}' {{ ckan_site_url }}/api/action/send_email_notifications;"
+              - "curl -rl -X POST -H 'Authorization: {{ ckan_admin_api_token }}' {{ ckan_site_url }}/api/action/send_phone_notifications;"
 
           restartPolicy: Never
 


### PR DESCRIPTION
## Description

Improvement to the notification cronjob. In DMS we are still using an ansible variable ckan_sysadmin_api_key.  But we also now have ckan_admin_api_token.  Api keys have been deprecated (I think someone has just set the secret to a token in AWS since it is working). But it would be better to clean this up and get rid of the duplicate ansible variable that is only used in DMS. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The GitHub ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
