### PR TITLE
Fix local datastore bootstrap

### DIFF
--- a/roles/ckan/tasks/deploy.yml
+++ b/roles/ckan/tasks/deploy.yml
@@ -107,7 +107,7 @@
   become: false
   with_items:
     - ckandb_job.yaml
-  when: (fjelltopp_env_type != 'local') or (ckan_datapusher_enable == 'true')
+  when: (fjelltopp_env_type != 'local')
 
 - name: Deploy CKAN
   kubernetes.core.k8s:

--- a/roles/ckan/templates/ckan/ckan_bootstrap.sh
+++ b/roles/ckan/templates/ckan/ckan_bootstrap.sh
@@ -1,9 +1,20 @@
 #!/bin/sh
 CONFIG=/etc/ckan/production.ini
+
+{% if ckan_datapusher_enable == 'true' %}
+echo "Making datastore user"
+psql "${CKAN_SQLALCHEMY_URL}" -c "CREATE ROLE datastore NOSUPERUSER NOCREATEDB NOCREATEROLE LOGIN PASSWORD '{{ ckan_ds_rw_pass }}';"
+echo "Making datastore_ro user"
+psql "${CKAN_SQLALCHEMY_URL}" -c "CREATE ROLE datastore_ro NOSUPERUSER NOCREATEDB NOCREATEROLE LOGIN PASSWORD '{{ ckan_ds_ro_pass }}';"
+echo "Making datastore db"
+psql "${CKAN_SQLALCHEMY_URL}" -c "CREATE DATABASE datastore OWNER ckan ENCODING 'utf-8';"
+echo "Setup datastore permissions"
+ckan -c "$CONFIG" datastore set-permissions | psql "${CKAN_SQLALCHEMY_URL}"
+{% endif %}
+
 # we're making sure to run our custom entrypoint.
 /usr/lib/ckan/ckan-entrypoint.sh
-echo "DB init:"
-ckan -c "$CONFIG" db init
+
 echo "Add admin user:"
 ckan -c "$CONFIG" user add admin email="admin@localhost" name="admin" fullname="Admin" password="fjelltopp" apikey="{{ ckan_admin_api_key }}" id="{{ ckan_admin_user_id }}"
 echo "Set apikey:"
@@ -12,8 +23,6 @@ echo "Create API token:"
 psql "${CKAN_SQLALCHEMY_URL}"  -c "INSERT INTO api_token VALUES ('{{ ckan_admin_api_token_unencoded }}', 'Default Token', '{{ ckan_admin_user_id }}', now()) ON CONFLICT DO NOTHING;"
 echo "make admin superuser"
 ckan -c "$CONFIG" sysadmin add admin
-echo "Set datastore permissions"
-ckan -c "$CONFIG" datastore set-permissions | psql "${CKAN_SQLALCHEMY_URL}"
 echo "Build search index"
 ckan -c "$CONFIG" search-index rebuild
 echo bootstrap finished


### PR DESCRIPTION
## Description

This PR fixes the local datastore bootstrap.  Previously this was coupled into the RDS bootstrapping process, creating problems as cloud environment databases had admin and ckan users sharing password.  This was fixed [here](https://github.com/fjelltopp/fjelltopp-ansible/pull/46), but left a problem for thos CKAN instances with datapusher enabled. The local dev env db is bootstrapped in a different way to the cloud dbs.  This PR ensures that the RDS bootstrapping doesn't take place in local, but that the datastore db and users are still created if datapushed is enabled. 

I believe this should close issue: https://github.com/fjelltopp/fjelltopp-infrastructure/issues/333

Tested manually for WAC 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The GitHub ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
