### PR TITLE
Cleanup SSO configuration

### DIFF
--- a/roles/ckan/templates/ckan/ckan_production.ini
+++ b/roles/ckan/templates/ckan/ckan_production.ini
@@ -91,7 +91,6 @@ ckan.auth.public_user_details = true
 ckan.auth.public_activity_stream_detail = true
 ckan.auth.allow_dataset_collaborators = {{ ckan_collaborators }}
 ckan.auth.create_default_api_keys = false
-ckan.auth.login_view = {{ ckan_login_form_view }}
 
 ## API Token Settings
 api_token.nbytes = 60

--- a/roles/ckan/templates/kubernetes/ckan.yaml
+++ b/roles/ckan/templates/kubernetes/ckan.yaml
@@ -9,9 +9,11 @@ data:
   jwt-rs256.key.pub: "{{ ckan_jwt_public_key|string | b64encode  }}"
   ckan-uwsgi.ini: "{{ lookup('template', 'templates/ckan/ckan-uwsgi.ini') | b64encode }}"
   wsgi.py: "{{ lookup('template', 'templates/ckan/wsgi.py') | b64encode }}"
+  saml_idp.crt: "{{ ckan_saml_idp_cert | b64encode }}"
 {% if ckan_googleanalytics_enable %}
   google_analytics_credentials.json: "{{ ckan_googleanalytics_credentials | b64encode }}"
 {% endif %}
+
 type: Opaque
 
 {% if fjelltopp_env_type == 'local' %}
@@ -153,13 +155,8 @@ spec:
 {% if fjelltopp_cloud_provider != 'azure' %}
             - name: AWS_DEFAULT_REGION
               value: "{{ aws_region }}"
-            - name: CKAN_SAML_IDP_CERT
-              value: |-
-                {{ ckan_saml_idp_cert }}
 {% endif %}
 {% if fjelltopp_env_type == 'local' %}
-            - name: CKAN_SAML_IDP_CERT
-              value: "{{ ckan_saml_idp_cert }}"
             - name: HOME
               value: "/usr/lib/ckan"
 {% endif %}

--- a/roles/ckan/vars/secrets.yml
+++ b/roles/ckan/vars/secrets.yml
@@ -14,8 +14,3 @@ ckan_beaker_secret: "{{ lookup('aws_secret', application_namespace + '_ckan_beak
                     on_missing='skip', on_deleted='skip') }}"
 ckan_api_secret: "{{ lookup('aws_secret', application_namespace + '_ckan_api_secret' , region = aws_region,
                     on_missing='skip', on_deleted='skip') }}"
-
-#The following is not really a secret but a certificate
-#This is uploaded manually to AWS #TODO
-ckan_saml_idp_cert: "{{ lookup('aws_secret', application_namespace + '_ckan_saml_idp_cert' , region = aws_region,
-                    on_missing='skip', on_deleted='skip') }}"


### PR DESCRIPTION
## Description

Makes some cleanup of the SSO configuration, as part of getting SSO working for who_afro_ckan:

- Put the login view into ckan_extras.  Means we're not maintaining a seperate ansible variable for it. 
- read the idp certificate into a file in the same way we read JWT keys and google analytics credentials. 

[This PR](https://github.com/fjelltopp/fjelltopp-infrastructure/pull/347) includes necessary config changes for WHO Romania CKAN that are raised by the changes here. 



## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The GitHub ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
