### PR TITLE
feat: Adds google analytics private key reader

### DIFF
--- a/roles/ckan/tasks/secrets.yml
+++ b/roles/ckan/tasks/secrets.yml
@@ -144,6 +144,11 @@
         ckan_api_secret: "{{ new_ckan_api_secret }}"
       when: new_ckan_api_secret|default(None)
 
+    - name: Read Google Analytics private key
+      set_fact:
+        ckan_googleanalytics_private_key: "{{ lookup('amazon.aws.aws_secret', '{{ application_namespace }}_ckan_googleanalytics_private_key') }}"
+      when: not ckan_googleanalytics_private_key|default(None))
+
 
   become: false
   when: fjelltopp_env_type != 'local'


### PR DESCRIPTION
## Description

Allow reading of ckan google analytics private key from aws secrets.

Relates https://github.com/fjelltopp/fjelltopp-infrastructure/pull/345

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The GitHub ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
