### PR TITLE
fix: rebuild Solr search index after every deploy

### DIFF
--- a/roles/ckan/tasks/deploy.yml
+++ b/roles/ckan/tasks/deploy.yml
@@ -127,6 +127,39 @@
     - ckan_ingress.yaml
     - ckan_cronjob.yaml
 
+- name: Wait for CKAN deployment to be ready
+  kubernetes.core.k8s_info:
+    kind: Deployment
+    name: ckan
+    namespace: "{{ application_namespace }}"
+    kubeconfig: "{{ kubeconfig }}"
+    wait: true
+    wait_condition:
+      type: Available
+      status: "True"
+    wait_timeout: 300
+  become: false
+
+- name: Get CKAN pod name
+  kubernetes.core.k8s_info:
+    kind: Pod
+    namespace: "{{ application_namespace }}"
+    kubeconfig: "{{ kubeconfig }}"
+    label_selectors:
+      - app=ckan
+    field_selectors:
+      - status.phase=Running
+  become: false
+  register: ckan_pods
+
+- name: Rebuild Solr search index
+  kubernetes.core.k8s_exec:
+    namespace: "{{ application_namespace }}"
+    kubeconfig: "{{ kubeconfig }}"
+    pod: "{{ ckan_pods.resources[0].metadata.name }}"
+    command: ckan --config /etc/ckan/production.ini search-index rebuild
+  become: false
+
 - name: Setup backup job
   kubernetes.core.k8s:
     state: present


### PR DESCRIPTION
## Problem

If the Solr pod restarts between deploys (e.g. due to an eviction or node replacement), the search index is lost. CKAN datasets still exist in the database but are invisible on the site until the index is rebuilt manually with:

```
ckan --config /etc/ckan/production.ini search-index rebuild
```

## Fix

Adds three tasks to `roles/ckan/tasks/deploy.yml` after the "Deploy CKAN" step:

1. **Wait for CKAN deployment to be ready** — blocks until the `Available` condition is `True` (up to 5 minutes), ensuring the new pod is running before we exec into it
2. **Get CKAN pod name** — finds a running pod with `app=ckan`
3. **Rebuild Solr search index** — execs `ckan search-index rebuild` inside the pod

This runs on every deploy, which is safe — rebuilding an already-populated index is idempotent and takes a few seconds.

## Test plan

- [ ] Trigger a deploy to `dms_dev` — verify the "Rebuild Solr search index" task appears and completes green
- [ ] Confirm datasets are visible on the site immediately after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)