### PR TITLE
feat: add setup-eks-v2 Ansible role and playbook for ckan-v2 cluster provisioning

### DIFF
--- a/eksctl/cluster-config.yaml
+++ b/eksctl/cluster-config.yaml
@@ -1,0 +1,35 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: ckan-v2
+  region: af-south-1
+  version: "1.36"
+
+vpc:
+  id: "${EKS_VPC_ID}"
+  subnets:
+    public:
+      af-south-1a: { id: "${EKS_SUBNET_AF_SOUTH_1A}" }
+      af-south-1b: { id: "${EKS_SUBNET_AF_SOUTH_1B}" }
+      af-south-1c: { id: "${EKS_SUBNET_AF_SOUTH_1C}" }
+
+managedNodeGroups:
+  - name: ckan-workers
+    instanceType: t3.medium
+    minSize: 1
+    maxSize: 3
+    desiredCapacity: 1
+    amiFamily: AmazonLinux2023
+    iam:
+      withAddonPolicies:
+        cloudWatch: true
+        efs: true
+
+addons:
+  - name: vpc-cni
+    version: latest
+  - name: coredns
+    version: latest
+  - name: kube-proxy
+    version: latest

--- a/eksctl/cluster-config.yaml
+++ b/eksctl/cluster-config.yaml
@@ -27,6 +27,9 @@ managedNodeGroups:
         efs: true
 
 addons:
+  # version: latest resolves at provision time to the newest version compatible
+  # with k8s 1.36. To pin for reproducibility, replace with output of:
+  #   eksctl utils describe-addon-versions --kubernetes-version 1.36 --name <addon>
   - name: vpc-cni
     version: latest
   - name: coredns

--- a/group_vars/all/all.yml
+++ b/group_vars/all/all.yml
@@ -11,6 +11,7 @@ kubeconfig: "{{ ansible_env.HOME}}/.kube/config"
 
 # EKS
 eks_cluster_name: ckan
+eks_cluster_name_v2: "ckan-v2"
 # https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html
 eks_worker_ami_id: "ami-0607bdd6d5e5d9050"
 eks_stack_name: "fjelltopp-eks"

--- a/roles/setup-eks-v2/defaults/main.yml
+++ b/roles/setup-eks-v2/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+eks_cluster_name_v2: "ckan-v2"
+cloudwatch_logs_retention: "30"

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -230,8 +230,18 @@
     if isinstance(policy['Statement'], dict):
         policy['Statement'] = [policy['Statement']]
     new_arn = '{{ new_node_role_arn_result.stdout | trim }}'
+    giftless_bucket = '{{ giftless_s3_bucket }}'
+    giftless_resources = {f'arn:aws:s3:::{giftless_bucket}', f'arn:aws:s3:::{giftless_bucket}/*'}
     for stmt in policy['Statement']:
         if stmt.get('Effect') != 'Allow':
+            continue
+        action = stmt.get('Action', '')
+        if action != 's3:*':
+            continue
+        resources = stmt.get('Resource', [])
+        if isinstance(resources, str):
+            resources = [resources]
+        if not giftless_resources.issubset(set(resources)):
             continue
         principal = stmt.get('Principal', {})
         if isinstance(principal, dict) and 'AWS' in principal:

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -173,6 +173,7 @@
     --query 'nodegroup.nodeRole'
     --output text
   register: new_node_role_arn_result
+  changed_when: false
   become: false
 
 - name: Set new node role name fact

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -152,6 +152,7 @@
     --security-groups {{ ((efs_sgs_result.stdout | from_json) + [new_cluster_sg_id]) | unique | join(' ') }}
     --region "{{ aws_region }}"
   become: false
+  when: new_cluster_sg_id not in (efs_sgs_result.stdout | from_json)
 
 # 7. Get AWS account ID
 - name: Get AWS account ID

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -193,13 +193,28 @@
     --query Policy
     --output text
   register: s3_policy_raw
+  changed_when: false
+  become: false
+  when: use_giftless | bool
+
+- name: Create temp file for current S3 policy
+  ansible.builtin.tempfile:
+    suffix: _giftless_s3_policy_current.json
+  register: s3_policy_current_tmp
+  become: false
+  when: use_giftless | bool
+
+- name: Create temp file for updated S3 policy
+  ansible.builtin.tempfile:
+    suffix: _giftless_s3_policy_updated.json
+  register: s3_policy_updated_tmp
   become: false
   when: use_giftless | bool
 
 - name: Write current S3 policy to temp file
   copy:
     content: "{{ s3_policy_raw.stdout }}"
-    dest: /tmp/giftless_s3_policy_current.json
+    dest: "{{ s3_policy_current_tmp.path }}"
   become: false
   when: use_giftless | bool
 
@@ -207,7 +222,7 @@
   shell: |
     python3 << 'EOF'
     import json
-    with open('/tmp/giftless_s3_policy_current.json') as f:
+    with open('{{ s3_policy_current_tmp.path }}') as f:
         policy = json.loads(f.read())
     if isinstance(policy['Statement'], dict):
         policy['Statement'] = [policy['Statement']]
@@ -221,7 +236,7 @@
             if new_arn not in arns:
                 arns.append(new_arn)
             stmt['Principal']['AWS'] = arns
-    with open('/tmp/giftless_s3_policy_updated.json', 'w') as f:
+    with open('{{ s3_policy_updated_tmp.path }}', 'w') as f:
         json.dump(policy, f)
     EOF
   become: false
@@ -231,9 +246,19 @@
   command: >
     aws s3api put-bucket-policy
     --bucket "{{ giftless_s3_bucket }}"
-    --policy file:///tmp/giftless_s3_policy_updated.json
+    --policy "file://{{ s3_policy_updated_tmp.path }}"
   become: false
   when: use_giftless | bool
+
+- name: Clean up S3 policy temp files
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  become: false
+  when: use_giftless | bool
+  loop:
+    - "{{ s3_policy_current_tmp.path }}"
+    - "{{ s3_policy_updated_tmp.path }}"
 
 # 10. Create CloudWatch namespace
 - name: Create amazon-cloudwatch namespace in ckan-v2

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -231,6 +231,8 @@
         policy['Statement'] = [policy['Statement']]
     new_arn = '{{ new_node_role_arn_result.stdout | trim }}'
     for stmt in policy['Statement']:
+        if stmt.get('Effect') != 'Allow':
+            continue
         principal = stmt.get('Principal', {})
         if isinstance(principal, dict) and 'AWS' in principal:
             arns = principal['AWS']

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -206,6 +206,8 @@
     import json
     with open('/tmp/giftless_s3_policy_current.json') as f:
         policy = json.loads(f.read())
+    if isinstance(policy['Statement'], dict):
+        policy['Statement'] = [policy['Statement']]
     new_arn = '{{ new_node_role_arn_result.stdout | trim }}'
     for stmt in policy['Statement']:
         principal = stmt.get('Principal', {})

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -79,6 +79,7 @@
     --query 'cluster.resourcesVpcConfig.clusterSecurityGroupId'
     --output text
   register: new_cluster_sg_result
+  changed_when: false
   become: false
 
 - name: Set new cluster SG fact

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -20,6 +20,38 @@
     --kubeconfig "{{ ansible_env.HOME }}/.kube/{{ eks_cluster_name_v2 }}_cluster_config"
   become: false
 
+- name: Get cluster details for Secrets Manager
+  ansible.builtin.command: >
+    aws eks describe-cluster
+    --name "{{ eks_cluster_name_v2 }}"
+    --region "{{ aws_region }}"
+    --query 'cluster.{ca: certificateAuthority.data, endpoint: endpoint, arn: arn}'
+    --output json
+  register: cluster_details_raw
+  changed_when: false
+  become: false
+
+- name: Parse cluster details
+  ansible.builtin.set_fact:
+    cluster_details: "{{ cluster_details_raw.stdout | from_json }}"
+  become: false
+
+- name: Store EKS cluster config in Secrets Manager
+  community.aws.aws_secret:
+    aws_region: "{{ aws_region }}"
+    name: "eks_{{ eks_cluster_name_v2 }}_{{ item.name }}"
+    state: present
+    secret_type: "string"
+    secret: "{{ item.secret }}"
+  become: false
+  with_items:
+    - name: ca
+      secret: "{{ cluster_details.ca }}"
+    - name: endpoint
+      secret: "{{ cluster_details.endpoint }}"
+    - name: arn
+      secret: "{{ cluster_details.arn }}"
+
 # 3. Get the cluster security group ID (used by MNG nodes)
 - name: Get ckan-v2 cluster security group ID
   command: >

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -1,5 +1,15 @@
 ---
 # 1. Provision the cluster via eksctl
+- name: Check if EKS cluster already exists
+  command: >
+    aws eks describe-cluster
+    --name "{{ eks_cluster_name_v2 }}"
+    --region "{{ aws_region }}"
+  register: eks_cluster_check
+  failed_when: false
+  changed_when: false
+  become: false
+
 - name: Create EKS cluster ckan-v2 with eksctl
   command: >
     eksctl create cluster
@@ -9,6 +19,7 @@
     EKS_SUBNET_AF_SOUTH_1A: "{{ eks_subnet_af_south_1a }}"
     EKS_SUBNET_AF_SOUTH_1B: "{{ eks_subnet_af_south_1b }}"
     EKS_SUBNET_AF_SOUTH_1C: "{{ eks_subnet_af_south_1c }}"
+  when: eks_cluster_check.rc != 0
   become: false
 
 # 2. Generate a named kubeconfig file for ckan-v2

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -87,7 +87,8 @@
     new_cluster_sg_id: "{{ new_cluster_sg_result.stdout | trim }}"
 
 # 4. Allow new cluster nodes to access RDS (add rule, keep existing rules)
-- name: Allow ckan-v2 nodes to access RDS security group
+# Note: description uses eks_cluster_name (original cluster) intentionally — SG descriptions are immutable after creation.
+- name: Allow ckan-v2 nodes to access RDS SG (description uses original cluster name - immutable)
   amazon.aws.ec2_group:
     name: "{{ application_namespace }}-rds-sg"
     description: "Access for {{ eks_cluster_name }} EKS cluster"

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -122,7 +122,7 @@
     aws efs describe-mount-targets
     --file-system-id "{{ efs_info.efs[0].file_system_id }}"
     --region "{{ aws_region }}"
-    --query "MountTargets[?IpAddress==`{{ eks_efs_ip }}`].MountTargetId | [0]"
+    --query "MountTargets[?IpAddress=='{{ eks_efs_ip }}'].MountTargetId | [0]"
     --output text
   register: efs_mount_target_id_result
   changed_when: false

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -154,6 +154,7 @@
 - name: Get AWS account ID
   command: aws sts get-caller-identity --query Account --output text
   register: aws_account_id_result
+  changed_when: false
   become: false
 
 - name: Set account ID fact

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -109,6 +109,11 @@
   register: efs_info
   become: false
 
+- name: Fail if no EFS found
+  ansible.builtin.fail:
+    msg: "No EFS found with tag Name={{ eks_cluster_name }}-efs. Ensure the EFS exists before running this role."
+  when: efs_info.efs | length == 0
+
 - name: Get EFS mount target ID
   command: >
     aws efs describe-mount-targets
@@ -118,6 +123,11 @@
     --output text
   register: efs_mount_target_id_result
   become: false
+
+- name: Fail if no EFS mount target found for the given IP
+  ansible.builtin.fail:
+    msg: "No EFS mount target found with IP {{ eks_efs_ip }} on filesystem {{ efs_info.efs[0].file_system_id }}. Check eks_efs_ip."
+  when: efs_mount_target_id_result.stdout | trim in ['None', '']
 
 # 6. Add new cluster SG to EFS mount target security groups (keep existing SGs)
 - name: Get current EFS mount target security groups

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -124,6 +124,7 @@
     --query "MountTargets[?IpAddress==`{{ eks_efs_ip }}`].MountTargetId | [0]"
     --output text
   register: efs_mount_target_id_result
+  changed_when: false
   become: false
 
 - name: Fail if no EFS mount target found for the given IP

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -191,91 +191,95 @@
   become: false
 
 # 9. Update Giftless S3 bucket policy to include new node role ARN
-- name: Get current Giftless S3 bucket policy
-  command: >
-    aws s3api get-bucket-policy
-    --bucket "{{ giftless_s3_bucket }}"
-    --query Policy
-    --output text
-  register: s3_policy_raw
-  changed_when: false
-  become: false
+- name: Update Giftless S3 bucket policy to include new node role ARN
   when: use_giftless | bool
+  become: false
+  block:
+    - name: Get current Giftless S3 bucket policy
+      command: >
+        aws s3api get-bucket-policy
+        --bucket "{{ giftless_s3_bucket }}"
+        --query Policy
+        --output text
+      register: s3_policy_raw
+      changed_when: false
 
-- name: Create temp file for current S3 policy
-  ansible.builtin.tempfile:
-    suffix: _giftless_s3_policy_current.json
-  register: s3_policy_current_tmp
-  become: false
-  when: use_giftless | bool
+    - name: Create temp file for current S3 policy
+      ansible.builtin.tempfile:
+        suffix: _giftless_s3_policy_current.json
+      register: s3_policy_current_tmp
 
-- name: Create temp file for updated S3 policy
-  ansible.builtin.tempfile:
-    suffix: _giftless_s3_policy_updated.json
-  register: s3_policy_updated_tmp
-  become: false
-  when: use_giftless | bool
+    - name: Create temp file for updated S3 policy
+      ansible.builtin.tempfile:
+        suffix: _giftless_s3_policy_updated.json
+      register: s3_policy_updated_tmp
 
-- name: Write current S3 policy to temp file
-  copy:
-    content: "{{ s3_policy_raw.stdout }}"
-    dest: "{{ s3_policy_current_tmp.path }}"
-  become: false
-  when: use_giftless | bool
+    - name: Write current S3 policy to temp file
+      copy:
+        content: "{{ s3_policy_raw.stdout }}"
+        dest: "{{ s3_policy_current_tmp.path }}"
 
-- name: Add new node role ARN to Giftless S3 bucket policy
-  shell: |
-    python3 << 'EOF'
-    import json
-    with open('{{ s3_policy_current_tmp.path }}') as f:
-        policy = json.loads(f.read())
-    if isinstance(policy['Statement'], dict):
-        policy['Statement'] = [policy['Statement']]
-    new_arn = '{{ new_node_role_arn_result.stdout | trim }}'
-    giftless_bucket = '{{ giftless_s3_bucket }}'
-    giftless_resources = {f'arn:aws:s3:::{giftless_bucket}', f'arn:aws:s3:::{giftless_bucket}/*'}
-    for stmt in policy['Statement']:
-        if stmt.get('Effect') != 'Allow':
-            continue
-        action = stmt.get('Action', '')
-        if action != 's3:*':
-            continue
-        resources = stmt.get('Resource', [])
-        if isinstance(resources, str):
-            resources = [resources]
-        if not giftless_resources.issubset(set(resources)):
-            continue
-        principal = stmt.get('Principal', {})
-        if isinstance(principal, dict) and 'AWS' in principal:
-            arns = principal['AWS']
-            if isinstance(arns, str):
-                arns = [arns]
-            if new_arn not in arns:
-                arns.append(new_arn)
-            stmt['Principal']['AWS'] = arns
-    with open('{{ s3_policy_updated_tmp.path }}', 'w') as f:
-        json.dump(policy, f)
-    EOF
-  become: false
-  when: use_giftless | bool
+    - name: Add new node role ARN to Giftless S3 bucket policy
+      shell: |
+        python3 << 'EOF'
+        import json
+        with open('{{ s3_policy_current_tmp.path }}') as f:
+            policy = json.loads(f.read())
+        if isinstance(policy['Statement'], dict):
+            policy['Statement'] = [policy['Statement']]
+        new_arn = '{{ new_node_role_arn_result.stdout | trim }}'
+        giftless_bucket = '{{ giftless_s3_bucket }}'
+        giftless_resources = {f'arn:aws:s3:::{giftless_bucket}', f'arn:aws:s3:::{giftless_bucket}/*'}
+        changed = False
+        for stmt in policy['Statement']:
+            if stmt.get('Effect') != 'Allow':
+                continue
+            action = stmt.get('Action', '')
+            if action != 's3:*':
+                continue
+            resources = stmt.get('Resource', [])
+            if isinstance(resources, str):
+                resources = [resources]
+            if not giftless_resources.issubset(set(resources)):
+                continue
+            principal = stmt.get('Principal', {})
+            if isinstance(principal, dict) and 'AWS' in principal:
+                arns = principal['AWS']
+                if isinstance(arns, str):
+                    arns = [arns]
+                if new_arn not in arns:
+                    arns.append(new_arn)
+                    changed = True
+                stmt['Principal']['AWS'] = arns
+        with open('{{ s3_policy_updated_tmp.path }}', 'w') as f:
+            json.dump(policy, f)
+        if changed:
+            print('changed')
+        EOF
+      register: s3_policy_update_result
+      changed_when: "'changed' in s3_policy_update_result.stdout"
 
-- name: Apply updated Giftless S3 bucket policy
-  command: >
-    aws s3api put-bucket-policy
-    --bucket "{{ giftless_s3_bucket }}"
-    --policy "file://{{ s3_policy_updated_tmp.path }}"
-  become: false
-  when: use_giftless | bool
+    - name: Apply updated Giftless S3 bucket policy
+      command: >
+        aws s3api put-bucket-policy
+        --bucket "{{ giftless_s3_bucket }}"
+        --policy "file://{{ s3_policy_updated_tmp.path }}"
+      when: s3_policy_update_result.changed
 
-- name: Clean up S3 policy temp files
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: absent
-  become: false
-  when: use_giftless | bool
-  loop:
-    - "{{ s3_policy_current_tmp.path }}"
-    - "{{ s3_policy_updated_tmp.path }}"
+  always:
+    - name: Clean up current S3 policy temp file
+      ansible.builtin.file:
+        path: "{{ s3_policy_current_tmp.path }}"
+        state: absent
+      become: false
+      when: s3_policy_current_tmp is defined and s3_policy_current_tmp.path is defined
+
+    - name: Clean up updated S3 policy temp file
+      ansible.builtin.file:
+        path: "{{ s3_policy_updated_tmp.path }}"
+        state: absent
+      become: false
+      when: s3_policy_updated_tmp is defined and s3_policy_updated_tmp.path is defined
 
 # 10. Create CloudWatch namespace
 - name: Create amazon-cloudwatch namespace in ckan-v2

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -93,6 +93,7 @@
     vpc_id: "{{ eks_vpc_id }}"
     region: "{{ aws_region }}"
     purge_rules: false
+    purge_rules_egress: false
     rules:
       - proto: tcp
         from_port: 5432

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -103,7 +103,7 @@
     aws efs describe-mount-targets
     --file-system-id "{{ efs_info.efs[0].file_system_id }}"
     --region "{{ aws_region }}"
-    --query 'MountTargets[0].MountTargetId'
+    --query "MountTargets[?IpAddress==`{{ eks_efs_ip }}`].MountTargetId | [0]"
     --output text
   register: efs_mount_target_id_result
   become: false

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -12,6 +12,13 @@
   become: false
 
 # 2. Generate a named kubeconfig file for ckan-v2
+- name: Ensure .kube directory exists
+  file:
+    path: "{{ ansible_env.HOME }}/.kube"
+    state: directory
+    mode: '0700'
+  become: false
+
 - name: Generate kubeconfig for ckan-v2
   command: >
     aws eks update-kubeconfig

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -6,7 +6,7 @@
     --name "{{ eks_cluster_name_v2 }}"
     --region "{{ aws_region }}"
   register: eks_cluster_check
-  failed_when: false
+  failed_when: eks_cluster_check.rc != 0 and 'ResourceNotFoundException' not in eks_cluster_check.stderr
   changed_when: false
   become: false
 

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -1,0 +1,246 @@
+---
+# 1. Provision the cluster via eksctl
+- name: Create EKS cluster ckan-v2 with eksctl
+  command: >
+    eksctl create cluster
+    --config-file {{ playbook_dir }}/eksctl/cluster-config.yaml
+  environment:
+    EKS_VPC_ID: "{{ eks_vpc_id }}"
+    EKS_SUBNET_AF_SOUTH_1A: "{{ eks_subnet_af_south_1a }}"
+    EKS_SUBNET_AF_SOUTH_1B: "{{ eks_subnet_af_south_1b }}"
+    EKS_SUBNET_AF_SOUTH_1C: "{{ eks_subnet_af_south_1c }}"
+  become: false
+
+# 2. Generate a named kubeconfig file for ckan-v2
+- name: Generate kubeconfig for ckan-v2
+  command: >
+    aws eks update-kubeconfig
+    --name "{{ eks_cluster_name_v2 }}"
+    --region "{{ aws_region }}"
+    --kubeconfig "{{ ansible_env.HOME }}/.kube/{{ eks_cluster_name_v2 }}_cluster_config"
+  become: false
+
+# 3. Get the cluster security group ID (used by MNG nodes)
+- name: Get ckan-v2 cluster security group ID
+  command: >
+    aws eks describe-cluster
+    --name "{{ eks_cluster_name_v2 }}"
+    --region "{{ aws_region }}"
+    --query 'cluster.resourcesVpcConfig.clusterSecurityGroupId'
+    --output text
+  register: new_cluster_sg_result
+  become: false
+
+- name: Set new cluster SG fact
+  set_fact:
+    new_cluster_sg_id: "{{ new_cluster_sg_result.stdout | trim }}"
+
+# 4. Allow new cluster nodes to access RDS (add rule, keep existing rules)
+- name: Allow ckan-v2 nodes to access RDS security group
+  amazon.aws.ec2_group:
+    name: "{{ application_namespace }}-rds-sg"
+    description: "Access for EKS clusters"
+    vpc_id: "{{ eks_vpc_id }}"
+    region: "{{ aws_region }}"
+    purge_rules: false
+    rules:
+      - proto: tcp
+        from_port: 5432
+        to_port: 5432
+        group_id: "{{ new_cluster_sg_id }}"
+  become: false
+
+# 5. Get EFS mount target ID for the existing EFS
+- name: Get existing EFS info
+  community.aws.efs_info:
+    aws_region: "{{ aws_region }}"
+    tags:
+      Name: "{{ eks_cluster_name }}-efs"
+  register: efs_info
+  become: false
+
+- name: Get EFS mount target ID
+  command: >
+    aws efs describe-mount-targets
+    --file-system-id "{{ efs_info.efs[0].file_system_id }}"
+    --region "{{ aws_region }}"
+    --query 'MountTargets[0].MountTargetId'
+    --output text
+  register: efs_mount_target_id_result
+  become: false
+
+# 6. Add new cluster SG to EFS mount target security groups (keep existing SGs)
+- name: Get current EFS mount target security groups
+  command: >
+    aws efs describe-mount-target-security-groups
+    --mount-target-id "{{ efs_mount_target_id_result.stdout | trim }}"
+    --region "{{ aws_region }}"
+    --query 'SecurityGroups'
+    --output json
+  register: efs_sgs_result
+  become: false
+
+- name: Add ckan-v2 node SG to EFS mount target
+  command: >
+    aws efs modify-mount-target-security-groups
+    --mount-target-id "{{ efs_mount_target_id_result.stdout | trim }}"
+    --security-groups {{ ((efs_sgs_result.stdout | from_json) + [new_cluster_sg_id]) | unique | join(' ') }}
+    --region "{{ aws_region }}"
+  become: false
+
+# 7. Get AWS account ID
+- name: Get AWS account ID
+  command: aws sts get-caller-identity --query Account --output text
+  register: aws_account_id_result
+  become: false
+
+- name: Set account ID fact
+  set_fact:
+    aws_account_id: "{{ aws_account_id_result.stdout | trim }}"
+
+# 8. Get new node group IAM role and attach secrets access policy
+- name: Get ckan-v2 node group IAM role ARN
+  command: >
+    aws eks describe-nodegroup
+    --cluster-name "{{ eks_cluster_name_v2 }}"
+    --nodegroup-name "ckan-workers"
+    --region "{{ aws_region }}"
+    --query 'nodegroup.nodeRole'
+    --output text
+  register: new_node_role_arn_result
+  become: false
+
+- name: Set new node role name fact
+  set_fact:
+    new_node_role_name: "{{ new_node_role_arn_result.stdout | trim | regex_replace('.*/', '') }}"
+
+- name: Attach eks-secrets-access-policy to ckan-v2 node role
+  community.aws.iam_role:
+    name: "{{ new_node_role_name }}"
+    managed_policy:
+      - "arn:aws:iam::{{ aws_account_id }}:policy/eks-secrets-access-policy"
+    purge_policies: false
+  become: false
+
+# 9. Update Giftless S3 bucket policy to include new node role ARN
+- name: Get current Giftless S3 bucket policy
+  command: >
+    aws s3api get-bucket-policy
+    --bucket "{{ giftless_s3_bucket }}"
+    --query Policy
+    --output text
+  register: s3_policy_raw
+  become: false
+  when: use_giftless | bool
+
+- name: Write current S3 policy to temp file
+  copy:
+    content: "{{ s3_policy_raw.stdout }}"
+    dest: /tmp/giftless_s3_policy_current.json
+  become: false
+  when: use_giftless | bool
+
+- name: Add new node role ARN to Giftless S3 bucket policy
+  shell: |
+    python3 << 'EOF'
+    import json
+    with open('/tmp/giftless_s3_policy_current.json') as f:
+        policy = json.loads(f.read())
+    new_arn = '{{ new_node_role_arn_result.stdout | trim }}'
+    for stmt in policy['Statement']:
+        principal = stmt.get('Principal', {})
+        if isinstance(principal, dict) and 'AWS' in principal:
+            arns = principal['AWS']
+            if isinstance(arns, str):
+                arns = [arns]
+            if new_arn not in arns:
+                arns.append(new_arn)
+            stmt['Principal']['AWS'] = arns
+    with open('/tmp/giftless_s3_policy_updated.json', 'w') as f:
+        json.dump(policy, f)
+    EOF
+  become: false
+  when: use_giftless | bool
+
+- name: Apply updated Giftless S3 bucket policy
+  command: >
+    aws s3api put-bucket-policy
+    --bucket "{{ giftless_s3_bucket }}"
+    --policy file:///tmp/giftless_s3_policy_updated.json
+  become: false
+  when: use_giftless | bool
+
+# 10. Create CloudWatch namespace
+- name: Create amazon-cloudwatch namespace in ckan-v2
+  kubernetes.core.k8s:
+    name: "amazon-cloudwatch"
+    api_version: v1
+    kind: Namespace
+    state: present
+    kubeconfig: "{{ ansible_env.HOME }}/.kube/{{ eks_cluster_name_v2 }}_cluster_config"
+  become: false
+
+# 11. Deploy Fluent-bit for CloudWatch integration
+- name: Deploy Fluent-bit to ckan-v2
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'templates/' + item) | from_yaml_all | list }}"
+    namespace: "amazon-cloudwatch"
+    kubeconfig: "{{ ansible_env.HOME }}/.kube/{{ eks_cluster_name_v2 }}_cluster_config"
+  become: false
+  with_items:
+    - fluent-bit-configmap.yaml
+    - fluent-bit.yaml
+
+# 12. Deploy Reloader
+- name: Add Stakater Helm repository
+  kubernetes.core.helm_repository:
+    name: stakater
+    repo_url: https://stakater.github.io/stakater-charts
+  become: false
+
+- name: Deploy Reloader to ckan-v2
+  kubernetes.core.helm:
+    namespace: default
+    update_repo_cache: true
+    name: reloader
+    chart_repo_url: https://stakater.github.io/stakater-charts
+    chart_ref: reloader
+    kubeconfig: "{{ ansible_env.HOME }}/.kube/{{ eks_cluster_name_v2 }}_cluster_config"
+    values:
+      ignoreSecrets: false
+      ignoreConfigMaps: false
+  become: false
+
+# 13. Deploy NFS subdir external provisioner (EFS StorageClass)
+- name: Add NFS provisioner Helm repository
+  kubernetes.core.helm_repository:
+    name: nfs-subdir-external-provisioner
+    repo_url: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
+  become: false
+
+- name: Deploy NFS provisioner for EFS to ckan-v2
+  kubernetes.core.helm:
+    update_repo_cache: true
+    name: nfs-subdir-external-provisioner
+    chart_repo_url: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner
+    chart_ref: nfs-subdir-external-provisioner
+    kubeconfig: "{{ ansible_env.HOME }}/.kube/{{ eks_cluster_name_v2 }}_cluster_config"
+    namespace: "default"
+    values:
+      storageClass:
+        name: "efs-client"
+        archiveOnDelete: true
+        accessModes: ReadWriteMany
+      nfs:
+        server: "{{ eks_efs_ip }}"
+        path: "/"
+        mountOptions:
+          - nfsvers=4.1
+          - rsize=1048576
+          - wsize=1048576
+          - hard
+          - timeo=600
+          - retrans=2
+          - noresvport
+  become: false

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -90,7 +90,7 @@
 - name: Allow ckan-v2 nodes to access RDS security group
   amazon.aws.ec2_group:
     name: "{{ application_namespace }}-rds-sg"
-    description: "Access for EKS clusters"
+    description: "Access for {{ eks_cluster_name }} EKS cluster"
     vpc_id: "{{ eks_vpc_id }}"
     region: "{{ aws_region }}"
     purge_rules: false

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -141,6 +141,7 @@
     --query 'SecurityGroups'
     --output json
   register: efs_sgs_result
+  changed_when: false
   become: false
 
 - name: Add ckan-v2 node SG to EFS mount target

--- a/roles/setup-eks-v2/templates/fluent-bit-configmap.yaml
+++ b/roles/setup-eks-v2/templates/fluent-bit-configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-cluster-info
+  namespace: amazon-cloudwatch
+data:
+  cluster.name: {{ eks_cluster_name_v2 }}
+  http.port: '2020'
+  http.server: 'On'
+  logs.region: {{ aws_region }}
+  logs.retention: "{{ cloudwatch_logs_retention }}"
+  read.head: 'Off'
+  read.tail: 'On'

--- a/roles/setup-eks-v2/templates/fluent-bit.yaml
+++ b/roles/setup-eks-v2/templates/fluent-bit.yaml
@@ -1,0 +1,375 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluent-bit
+  namespace: amazon-cloudwatch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fluent-bit-role
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - pods
+      - pods/logs
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fluent-bit-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluent-bit-role
+subjects:
+  - kind: ServiceAccount
+    name: fluent-bit
+    namespace: amazon-cloudwatch
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+  namespace: amazon-cloudwatch
+  labels:
+    k8s-app: fluent-bit
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush                     5
+        Log_Level                 info
+        Daemon                    off
+        Parsers_File              parsers.conf
+        HTTP_Server               ${HTTP_SERVER}
+        HTTP_Listen               0.0.0.0
+        HTTP_Port                 ${HTTP_PORT}
+        storage.path              /var/fluent-bit/state/flb-storage/
+        storage.sync              normal
+        storage.checksum          off
+        storage.backlog.mem_limit 5M
+        
+    @INCLUDE application-log.conf
+    @INCLUDE dataplane-log.conf
+    @INCLUDE host-log.conf
+  
+  application-log.conf: |
+    [INPUT]
+        Name                tail
+        Tag                 application.*
+        Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+        Path                /var/log/containers/*.log
+        Docker_Mode         On
+        Docker_Mode_Flush   5
+        Docker_Mode_Parser  container_firstline
+        Parser              docker
+        DB                  /var/fluent-bit/state/flb_container.db
+        Mem_Buf_Limit       50MB
+        Skip_Long_Lines     On
+        Refresh_Interval    10
+        Rotate_Wait         30
+        storage.type        filesystem
+        Read_from_Head      ${READ_FROM_HEAD}
+
+    [INPUT]
+        Name                tail
+        Tag                 application.*
+        Path                /var/log/containers/fluent-bit*
+        Parser              docker
+        DB                  /var/fluent-bit/state/flb_log.db
+        Mem_Buf_Limit       5MB
+        Skip_Long_Lines     On
+        Refresh_Interval    10
+        Read_from_Head      ${READ_FROM_HEAD}
+
+    [INPUT]
+        Name                tail
+        Tag                 application.*
+        Path                /var/log/containers/cloudwatch-agent*
+        Docker_Mode         On
+        Docker_Mode_Flush   5
+        Docker_Mode_Parser  cwagent_firstline
+        Parser              docker
+        DB                  /var/fluent-bit/state/flb_cwagent.db
+        Mem_Buf_Limit       5MB
+        Skip_Long_Lines     On
+        Refresh_Interval    10
+        Read_from_Head      ${READ_FROM_HEAD}
+
+    [FILTER]
+        Name                kubernetes
+        Match               application.*
+        Kube_URL            https://kubernetes.default.svc:443
+        Kube_Tag_Prefix     application.var.log.containers.
+        Merge_Log           On
+        Merge_Log_Key       log_processed
+        K8S-Logging.Parser  On
+        K8S-Logging.Exclude Off
+        Labels              Off
+        Annotations         Off
+
+    [OUTPUT]
+        Name                cloudwatch_logs
+        Match               application.*
+        region              ${AWS_REGION}
+        log_retention_days  ${LOG_RETENTION}
+        log_group_name      /aws/eks/${CLUSTER_NAME}/application
+        log_stream_prefix   eks-
+        auto_create_group   true
+        extra_user_agent    container-insights
+
+  dataplane-log.conf: |
+    [INPUT]
+        Name                systemd
+        Tag                 dataplane.systemd.*
+        Systemd_Filter      _SYSTEMD_UNIT=docker.service
+        Systemd_Filter      _SYSTEMD_UNIT=kubelet.service
+        DB                  /var/fluent-bit/state/systemd.db
+        Path                /var/log/journal
+        Read_From_Tail      ${READ_FROM_TAIL}
+
+    [INPUT]
+        Name                tail
+        Tag                 dataplane.tail.*
+        Path                /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+        Docker_Mode         On
+        Docker_Mode_Flush   5
+        Docker_Mode_Parser  container_firstline
+        Parser              docker
+        DB                  /var/fluent-bit/state/flb_dataplane_tail.db
+        Mem_Buf_Limit       50MB
+        Skip_Long_Lines     On
+        Refresh_Interval    10
+        Rotate_Wait         30
+        storage.type        filesystem
+        Read_from_Head      ${READ_FROM_HEAD}
+
+    [FILTER]
+        Name                modify
+        Match               dataplane.systemd.*
+        Rename              _HOSTNAME                   hostname
+        Rename              _SYSTEMD_UNIT               systemd_unit
+        Rename              MESSAGE                     message
+        Remove_regex        ^((?!hostname|systemd_unit|message).)*$
+
+    [FILTER]
+        Name                aws
+        Match               dataplane.*
+        imds_version        v1
+
+    [OUTPUT]
+        Name                cloudwatch_logs
+        Match               dataplane.*
+        region              ${AWS_REGION}
+        log_retention_days  ${LOG_RETENTION}
+        log_group_name      /aws/eks/${CLUSTER_NAME}/dataplane
+        log_stream_prefix   eks-
+        auto_create_group   true
+        extra_user_agent    container-insights
+    
+  host-log.conf: |
+    [INPUT]
+        Name                tail
+        Tag                 host.dmesg
+        Path                /var/log/dmesg
+        Parser              syslog
+        DB                  /var/fluent-bit/state/flb_dmesg.db
+        Mem_Buf_Limit       5MB
+        Skip_Long_Lines     On
+        Refresh_Interval    10
+        Read_from_Head      ${READ_FROM_HEAD}
+
+    [INPUT]
+        Name                tail
+        Tag                 host.messages
+        Path                /var/log/messages
+        Parser              syslog
+        DB                  /var/fluent-bit/state/flb_messages.db
+        Mem_Buf_Limit       5MB
+        Skip_Long_Lines     On
+        Refresh_Interval    10
+        Read_from_Head      ${READ_FROM_HEAD}
+
+    [INPUT]
+        Name                tail
+        Tag                 host.secure
+        Path                /var/log/secure
+        Parser              syslog
+        DB                  /var/fluent-bit/state/flb_secure.db
+        Mem_Buf_Limit       5MB
+        Skip_Long_Lines     On
+        Refresh_Interval    10
+        Read_from_Head      ${READ_FROM_HEAD}
+
+    [FILTER]
+        Name                aws
+        Match               host.*
+        imds_version        v1
+
+    [OUTPUT]
+        Name                cloudwatch_logs
+        Match               host.*
+        region              ${AWS_REGION}
+        log_retention_days  ${LOG_RETENTION}
+        log_group_name      /aws/eks/${CLUSTER_NAME}/host
+        log_stream_prefix   eks-
+        auto_create_group   true
+        extra_user_agent    container-insights
+
+  parsers.conf: |
+    [PARSER]
+        Name                docker
+        Format              json
+        Time_Key            time
+        Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+
+    [PARSER]
+        Name                syslog
+        Format              regex
+        Regex               ^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+        Time_Key            time
+        Time_Format         %b %d %H:%M:%S
+
+    [PARSER]
+        Name                container_firstline
+        Format              regex
+        Regex               (?<log>(?<="log":")\S(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
+        Time_Key            time
+        Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+
+    [PARSER]
+        Name                cwagent_firstline
+        Format              regex
+        Regex               (?<log>(?<="log":")\d{4}[\/-]\d{1,2}[\/-]\d{1,2}[ T]\d{2}:\d{2}:\d{2}(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
+        Time_Key            time
+        Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  namespace: amazon-cloudwatch
+  labels:
+    k8s-app: fluent-bit
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit
+  template:
+    metadata:
+      labels:
+        k8s-app: fluent-bit
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - name: fluent-bit
+        image: amazon/aws-for-fluent-bit:2.21.2
+        imagePullPolicy: Always
+        env:
+            - name: AWS_REGION
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: logs.region
+            - name: CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: cluster.name
+            - name: HTTP_SERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: http.server
+            - name: HTTP_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: http.port
+            - name: READ_FROM_HEAD
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: read.head
+            - name: READ_FROM_TAIL
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: read.tail
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NAME_SPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LOG_RETENTION
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: logs.retention
+            - name: CI_VERSION
+              value: "k8s/1.3.8"
+        resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 500m
+              memory: 100Mi
+        volumeMounts:
+        # Please don't change below read-only permissions
+        - name: fluentbitstate
+          mountPath: /var/fluent-bit/state
+        - name: varlog
+          mountPath: /var/log
+          readOnly: true
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: fluent-bit-config
+          mountPath: /fluent-bit/etc/
+        - name: runlogjournal
+          mountPath: /run/log/journal
+          readOnly: true
+        - name: dmesg
+          mountPath: /var/log/dmesg
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: fluentbitstate
+        hostPath:
+          path: /var/fluent-bit/state
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: fluent-bit-config
+        configMap:
+          name: fluent-bit-config
+      - name: runlogjournal
+        hostPath:
+          path: /run/log/journal
+      - name: dmesg
+        hostPath:
+          path: /var/log/dmesg
+      serviceAccountName: fluent-bit
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - operator: "Exists"
+        effect: "NoExecute"
+      - operator: "Exists"
+        effect: "NoSchedule"

--- a/roles/setup-eks-v2/templates/fluent-bit.yaml
+++ b/roles/setup-eks-v2/templates/fluent-bit.yaml
@@ -349,9 +349,6 @@ spec:
       - name: varlog
         hostPath:
           path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
       - name: fluent-bit-config
         configMap:
           name: fluent-bit-config

--- a/roles/setup-eks-v2/templates/fluent-bit.yaml
+++ b/roles/setup-eks-v2/templates/fluent-bit.yaml
@@ -17,7 +17,7 @@ rules:
     resources:
       - namespaces
       - pods
-      - pods/logs
+      - pods/log
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/roles/setup-eks-v2/templates/fluent-bit.yaml
+++ b/roles/setup-eks-v2/templates/fluent-bit.yaml
@@ -161,7 +161,7 @@ data:
     [FILTER]
         Name                aws
         Match               dataplane.*
-        imds_version        v1
+        imds_version        v2
 
     [OUTPUT]
         Name                cloudwatch_logs
@@ -210,7 +210,7 @@ data:
     [FILTER]
         Name                aws
         Match               host.*
-        imds_version        v1
+        imds_version        v2
 
     [OUTPUT]
         Name                cloudwatch_logs

--- a/roles/setup-eks-v2/templates/fluent-bit.yaml
+++ b/roles/setup-eks-v2/templates/fluent-bit.yaml
@@ -128,7 +128,7 @@ data:
     [INPUT]
         Name                systemd
         Tag                 dataplane.systemd.*
-        Systemd_Filter      _SYSTEMD_UNIT=docker.service
+        Systemd_Filter      _SYSTEMD_UNIT=containerd.service
         Systemd_Filter      _SYSTEMD_UNIT=kubelet.service
         DB                  /var/fluent-bit/state/systemd.db
         Path                /var/log/journal

--- a/roles/setup-eks-v2/templates/fluent-bit.yaml
+++ b/roles/setup-eks-v2/templates/fluent-bit.yaml
@@ -333,9 +333,6 @@ spec:
         - name: varlog
           mountPath: /var/log
           readOnly: true
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
         - name: fluent-bit-config
           mountPath: /fluent-bit/etc/
         - name: runlogjournal

--- a/roles/setup-eks-v2/tests/inventory
+++ b/roles/setup-eks-v2/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/setup_eks_v2.yml
+++ b/setup_eks_v2.yml
@@ -1,0 +1,38 @@
+---
+- hosts: all
+  connection: local
+  become: false
+
+  pre_tasks:
+    - name: Download required Ansible collections
+      command: "ansible-galaxy collection install -r roles/requirements.yml --force"
+      delegate_to: localhost
+      changed_when: false
+      become: false
+      tags: setup
+
+    - name: Load VPC and EFS variables from .env
+      set_fact:
+        eks_vpc_id: "{{ lookup('env', 'EKS_VPC_ID') }}"
+        eks_subnet_af_south_1a: "{{ lookup('env', 'EKS_SUBNET_AF_SOUTH_1A') }}"
+        eks_subnet_af_south_1b: "{{ lookup('env', 'EKS_SUBNET_AF_SOUTH_1B') }}"
+        eks_subnet_af_south_1c: "{{ lookup('env', 'EKS_SUBNET_AF_SOUTH_1C') }}"
+        eks_efs_ip: "{{ lookup('env', 'EKS_EFS_IP') }}"
+      become: false
+
+    - name: Validate required variables are set
+      assert:
+        that:
+          - eks_vpc_id | length > 0
+          - eks_subnet_af_south_1a | length > 0
+          - eks_subnet_af_south_1b | length > 0
+          - eks_subnet_af_south_1c | length > 0
+          - eks_efs_ip | length > 0
+        fail_msg: "Required environment variables missing. Source dms-infrastructure/.env before running."
+      become: false
+
+- hosts: all
+  connection: local
+  become: false
+  roles:
+    - { role: setup-eks-v2, tags: ["setup", "all", "eks-v2"] }

--- a/setup_eks_v2.yml
+++ b/setup_eks_v2.yml
@@ -12,7 +12,7 @@
       become: false
       tags: [always, setup]
 
-    - name: Load VPC and EFS variables from .env
+    - name: Load VPC and EFS variables from environment
       set_fact:
         eks_vpc_id: "{{ lookup('env', 'EKS_VPC_ID') }}"
         eks_subnet_af_south_1a: "{{ lookup('env', 'EKS_SUBNET_AF_SOUTH_1A') }}"

--- a/setup_eks_v2.yml
+++ b/setup_eks_v2.yml
@@ -9,7 +9,7 @@
       delegate_to: localhost
       changed_when: false
       become: false
-      tags: setup
+      tags: [always, setup]
 
     - name: Load VPC and EFS variables from .env
       set_fact:

--- a/setup_eks_v2.yml
+++ b/setup_eks_v2.yml
@@ -7,6 +7,7 @@
     - name: Download required Ansible collections
       command: "ansible-galaxy collection install -r roles/requirements.yml --force"
       delegate_to: localhost
+      run_once: true
       changed_when: false
       become: false
       tags: [always, setup]

--- a/setup_eks_v2.yml
+++ b/setup_eks_v2.yml
@@ -35,6 +35,18 @@
       become: false
       tags: always
 
+    - name: Validate runtime variables match eksctl cluster-config.yaml assumptions
+      assert:
+        that:
+          - aws_region == 'af-south-1'
+          - eks_cluster_name_v2 == 'ckan-v2'
+        fail_msg: >-
+          aws_region ({{ aws_region }}) must be 'af-south-1' and
+          eks_cluster_name_v2 ({{ eks_cluster_name_v2 }}) must be 'ckan-v2'
+          to match eksctl/cluster-config.yaml.
+      become: false
+      tags: always
+
 - hosts: all
   connection: local
   become: false

--- a/setup_eks_v2.yml
+++ b/setup_eks_v2.yml
@@ -18,7 +18,9 @@
         eks_subnet_af_south_1b: "{{ lookup('env', 'EKS_SUBNET_AF_SOUTH_1B') }}"
         eks_subnet_af_south_1c: "{{ lookup('env', 'EKS_SUBNET_AF_SOUTH_1C') }}"
         eks_efs_ip: "{{ lookup('env', 'EKS_EFS_IP') }}"
+        aws_region: "{{ lookup('env', 'AWS_REGION') }}"
       become: false
+      tags: always
 
     - name: Validate required variables are set
       assert:
@@ -28,8 +30,10 @@
           - eks_subnet_af_south_1b | length > 0
           - eks_subnet_af_south_1c | length > 0
           - eks_efs_ip | length > 0
+          - aws_region | length > 0
         fail_msg: "Required environment variables missing. Source dms-infrastructure/.env before running."
       become: false
+      tags: always
 
 - hosts: all
   connection: local

--- a/setup_eks_v2.yml
+++ b/setup_eks_v2.yml
@@ -19,7 +19,6 @@
         eks_subnet_af_south_1b: "{{ lookup('env', 'EKS_SUBNET_AF_SOUTH_1B') }}"
         eks_subnet_af_south_1c: "{{ lookup('env', 'EKS_SUBNET_AF_SOUTH_1C') }}"
         eks_efs_ip: "{{ lookup('env', 'EKS_EFS_IP') }}"
-        aws_region: "{{ lookup('env', 'AWS_REGION') }}"
       become: false
       tags: always
 
@@ -31,18 +30,16 @@
           - eks_subnet_af_south_1b | length > 0
           - eks_subnet_af_south_1c | length > 0
           - eks_efs_ip | length > 0
-          - aws_region | length > 0
-        fail_msg: "Required environment variables missing. Source dms-infrastructure/.env before running."
+          - aws_region is defined and aws_region | length > 0
+        fail_msg: "Required environment variables missing. Source dms-infrastructure/.env and pass -e aws_region=<region>."
       become: false
       tags: always
 
     - name: Validate runtime variables match eksctl cluster-config.yaml assumptions
       assert:
         that:
-          - aws_region == 'af-south-1'
           - eks_cluster_name_v2 == 'ckan-v2'
         fail_msg: >-
-          aws_region ({{ aws_region }}) must be 'af-south-1' and
           eks_cluster_name_v2 ({{ eks_cluster_name_v2 }}) must be 'ckan-v2'
           to match eksctl/cluster-config.yaml.
       become: false


### PR DESCRIPTION
## Summary

This PR implements the Ansible automation needed to provision a new `ckan-v2` EKS cluster (Kubernetes 1.36, Amazon Linux 2023, Managed Node Groups) alongside the existing `ckan` cluster. It is part of a blue/green migration to address two health warnings:

1. The `ckan` cluster runs Kubernetes 1.31 (needs upgrading to 1.36)
2. The worker nodes use Amazon Linux 2, which reaches end-of-life 2026-06-30

Rather than upgrading in place (which requires 5 sequential minor version upgrades with manual CloudFormation node replacement each time), a new cluster is provisioned with the target configuration from day one.

**Changes:**
- `group_vars/all/all.yml` — adds `eks_cluster_name_v2: "ckan-v2"` alongside the existing variable
- `eksctl/cluster-config.yaml` — new eksctl cluster config: K8s 1.36, AL2023 AMI family, Managed Node Group, reusing the existing VPC and subnets
- `roles/setup-eks-v2/` — one-shot provisioning role that:
  - Runs `eksctl create cluster` to provision `ckan-v2`
  - Retrieves the new cluster's node security group
  - Adds that SG to the RDS security group (with `purge_rules: false` to preserve existing rules)
  - Adds that SG to the EFS mount target security groups
  - Attaches the existing `eks-secrets-access-policy` IAM managed policy to the new node role
  - Updates the Giftless S3 bucket policy to include the new node role ARN
  - Generates a kubeconfig for `ckan-v2` and writes cluster details to Secrets Manager (so `deploy-dms` can connect to it)
  - Deploys Fluent-bit (CloudWatch integration), Stakater Reloader, and the NFS subdir external provisioner (same configuration as the existing cluster)
- `setup_eks_v2.yml` — top-level playbook that loads VPC/subnet/EFS variables from environment, validates they are set, then runs the role

**What this does NOT change:** The existing `setup-eks` role, `amazon-eks-nodegroup.yaml`, and `setup_aws.yml` are left untouched until prod migration is complete.

**Companion PR:** `fjelltopp/dms-infrastructure` — adds the GitHub Actions workflow to run this playbook and parameterises the deploy workflow to target either cluster.

## Test plan

- [ ] Review eksctl cluster config matches existing VPC/subnet IDs (set in `dms-infrastructure/.env`)
- [ ] Review `setup-eks-v2` role tasks for correctness, especially SG merging logic and S3 policy update
- [ ] After merge: trigger the `Setup EKS v2 (ckan-v2)` workflow in `dms-infrastructure` and confirm cluster provisions successfully
- [ ] Confirm `deploy-dms` with `cluster_name=ckan-v2` deploys dev successfully and all services (CKAN, Giftless, EFS mounts) work

🤖 Generated with [Claude Code](https://claude.com/claude-code)