### PR TITLE
fix: use t3.large for ckan-v2 nodes to match existing cluster capacity

### DIFF
--- a/eksctl/cluster-config.yaml
+++ b/eksctl/cluster-config.yaml
@@ -16,7 +16,7 @@ vpc:
 
 managedNodeGroups:
   - name: ckan-workers
-    instanceType: t3.medium
+    instanceType: t3.large
     minSize: 1
     maxSize: 3
     desiredCapacity: 1


### PR DESCRIPTION
The existing `ckan` cluster runs 2× t3.large nodes. The eksctl config for `ckan-v2` was set to t3.medium (4 GB RAM), which is half the memory of t3.large (8 GB RAM) and insufficient for the CKAN workload.

Changes `instanceType: t3.medium` → `instanceType: t3.large` in `eksctl/cluster-config.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)