### PR TITLE
fix: pipe eksctl cluster config through envsubst for variable substitution

### DIFF
--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -13,12 +13,13 @@
 - name: Create EKS cluster ckan-v2 with eksctl
   shell: |
     set -euo pipefail
+    command -v envsubst > /dev/null 2>&1 || { echo "envsubst is required but not installed (install via: apt-get install gettext or brew install gettext)"; exit 1; }
     : "${EKS_VPC_ID:?EKS_VPC_ID is required}"
     : "${EKS_SUBNET_AF_SOUTH_1A:?EKS_SUBNET_AF_SOUTH_1A is required}"
     : "${EKS_SUBNET_AF_SOUTH_1B:?EKS_SUBNET_AF_SOUTH_1B is required}"
     : "${EKS_SUBNET_AF_SOUTH_1C:?EKS_SUBNET_AF_SOUTH_1C is required}"
     envsubst '$EKS_VPC_ID $EKS_SUBNET_AF_SOUTH_1A $EKS_SUBNET_AF_SOUTH_1B $EKS_SUBNET_AF_SOUTH_1C' \
-      < {{ playbook_dir }}/eksctl/cluster-config.yaml \
+      < "{{ playbook_dir }}/eksctl/cluster-config.yaml" \
       | eksctl create cluster --config-file -
   args:
     executable: /bin/bash

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -11,9 +11,9 @@
   become: false
 
 - name: Create EKS cluster ckan-v2 with eksctl
-  command: >
-    eksctl create cluster
-    --config-file {{ playbook_dir }}/eksctl/cluster-config.yaml
+  shell: |
+    envsubst < {{ playbook_dir }}/eksctl/cluster-config.yaml \
+      | eksctl create cluster --config-file -
   environment:
     EKS_VPC_ID: "{{ eks_vpc_id }}"
     EKS_SUBNET_AF_SOUTH_1A: "{{ eks_subnet_af_south_1a }}"

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -12,8 +12,16 @@
 
 - name: Create EKS cluster ckan-v2 with eksctl
   shell: |
-    envsubst < {{ playbook_dir }}/eksctl/cluster-config.yaml \
+    set -euo pipefail
+    : "${EKS_VPC_ID:?EKS_VPC_ID is required}"
+    : "${EKS_SUBNET_AF_SOUTH_1A:?EKS_SUBNET_AF_SOUTH_1A is required}"
+    : "${EKS_SUBNET_AF_SOUTH_1B:?EKS_SUBNET_AF_SOUTH_1B is required}"
+    : "${EKS_SUBNET_AF_SOUTH_1C:?EKS_SUBNET_AF_SOUTH_1C is required}"
+    envsubst '$EKS_VPC_ID $EKS_SUBNET_AF_SOUTH_1A $EKS_SUBNET_AF_SOUTH_1B $EKS_SUBNET_AF_SOUTH_1C' \
+      < {{ playbook_dir }}/eksctl/cluster-config.yaml \
       | eksctl create cluster --config-file -
+  args:
+    executable: /bin/bash
   environment:
     EKS_VPC_ID: "{{ eks_vpc_id }}"
     EKS_SUBNET_AF_SOUTH_1A: "{{ eks_subnet_af_south_1a }}"


### PR DESCRIPTION
## Summary

eksctl does not perform shell variable substitution in YAML config files — `${EKS_VPC_ID}` was being passed literally, causing:

```
api error InvalidVpcID.NotFound: The vpc ID '${eks_vpc_id}' does not exist
```

Fix: switch the `command` module to `shell` and pipe the config through `envsubst` before passing it to eksctl via stdin (`--config-file -`). The `environment` block already set the correct vars — they just weren't being substituted.

## Test plan

- [ ] Merge, cut a new release, update submodule pointer in dms-infrastructure, re-trigger `Setup EKS v2 (ckan-v2)` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)