### PR TITLE
fix: replace community.aws.iam_role with aws cli for policy attachment

### DIFF
--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -191,13 +191,23 @@
   set_fact:
     new_node_role_name: "{{ new_node_role_arn_result.stdout | trim | regex_replace('.*/', '') }}"
 
+- name: Get currently attached policies for ckan-v2 node role
+  command: >
+    aws iam list-attached-role-policies
+    --role-name "{{ new_node_role_name }}"
+    --query 'AttachedPolicies[].PolicyArn'
+    --output json
+  register: attached_policies_result
+  changed_when: false
+  become: false
+
 - name: Attach eks-secrets-access-policy to ckan-v2 node role
   command: >
     aws iam attach-role-policy
     --role-name "{{ new_node_role_name }}"
     --policy-arn "arn:aws:iam::{{ aws_account_id }}:policy/eks-secrets-access-policy"
-  changed_when: false
   become: false
+  when: '"arn:aws:iam::{{ aws_account_id }}:policy/eks-secrets-access-policy" not in (attached_policies_result.stdout | from_json)'
 
 # 9. Update Giftless S3 bucket policy to include new node role ARN
 - name: Update Giftless S3 bucket policy to include new node role ARN

--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -192,11 +192,11 @@
     new_node_role_name: "{{ new_node_role_arn_result.stdout | trim | regex_replace('.*/', '') }}"
 
 - name: Attach eks-secrets-access-policy to ckan-v2 node role
-  community.aws.iam_role:
-    name: "{{ new_node_role_name }}"
-    managed_policy:
-      - "arn:aws:iam::{{ aws_account_id }}:policy/eks-secrets-access-policy"
-    purge_policies: false
+  command: >
+    aws iam attach-role-policy
+    --role-name "{{ new_node_role_name }}"
+    --policy-arn "arn:aws:iam::{{ aws_account_id }}:policy/eks-secrets-access-policy"
+  changed_when: false
   become: false
 
 # 9. Update Giftless S3 bucket policy to include new node role ARN


### PR DESCRIPTION
`community.aws.iam_role` with `state: present` requires `assume_role_policy_document` even when only attaching a managed policy to an already-existing role. This causes the task to fail in EKS provisioning where the node role already exists (created by eksctl).

Replace with `aws iam attach-role-policy` which is idempotent and only needs the role name and policy ARN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)