### PR TITLE
fix: drop unsafe conditional on iam attach-role-policy task

### DIFF
--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -191,23 +191,13 @@
   set_fact:
     new_node_role_name: "{{ new_node_role_arn_result.stdout | trim | regex_replace('.*/', '') }}"
 
-- name: Get currently attached policies for ckan-v2 node role
-  command: >
-    aws iam list-attached-role-policies
-    --role-name "{{ new_node_role_name }}"
-    --query 'AttachedPolicies[].PolicyArn'
-    --output json
-  register: attached_policies_result
-  changed_when: false
-  become: false
-
 - name: Attach eks-secrets-access-policy to ckan-v2 node role
   command: >
     aws iam attach-role-policy
     --role-name "{{ new_node_role_name }}"
     --policy-arn "arn:aws:iam::{{ aws_account_id }}:policy/eks-secrets-access-policy"
+  changed_when: false
   become: false
-  when: '"arn:aws:iam::{{ aws_account_id }}:policy/eks-secrets-access-policy" not in (attached_policies_result.stdout | from_json)'
 
 # 9. Update Giftless S3 bucket policy to include new node role ARN
 - name: Update Giftless S3 bucket policy to include new node role ARN


### PR DESCRIPTION
Ansible marks command stdout as unsafe, so using it in a `when` clause raises `Conditional is marked as unsafe, and cannot be evaluated`.

`aws iam attach-role-policy` is already idempotent — attaching an already-attached policy returns success with no changes — so the preceding list-policies check and the `when` guard are both unnecessary. Removed both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)