### PR TITLE
fix: nightly prod-to-dev sync

### DIFF
--- a/roles/ckan/defaults/main.yml
+++ b/roles/ckan/defaults/main.yml
@@ -24,7 +24,7 @@ ckan_create_user_via_web: "true"
 ckan_collaborators: "false"
 ckan_default_views: "image_view text_view recline_view"
 
-restore_production_backup: false
+restore_production_backup: true
 
 ckan_extras: |-
 

--- a/roles/ckan/defaults/main.yml
+++ b/roles/ckan/defaults/main.yml
@@ -9,7 +9,7 @@ ckan_backup_access_key: "dummyvalue"
 ckan_backup_access_secret: "dummyvalue"
 ckan_backup_s3: "dummyvalue"
 ckan_backup_sql_directory_s3: "dummyvalue"
-ckan_backup_postgres_version: 13
+ckan_backup_postgres_version: 14
 ckan_debug_enabled: "false"
 
 fjelltopp_base_image: "fjelltopp/ubuntu:base"

--- a/roles/ckan/templates/ckan/db_backup.sh
+++ b/roles/ckan/templates/ckan/db_backup.sh
@@ -47,7 +47,7 @@ error(){
   if [ -z "$SKIP_SLACK" ]; then
     slack_channel="sentry-prod" slack_notify "{{ application_namespace }} CKAN DB SQL backup" "RDS SQL DB backup has failed on: $1." "ERROR"
   fi
-  return 1
+  exit 1
 }
 
 get_s3_backup_vars(){

--- a/roles/ckan/templates/ckan/db_restore.sh
+++ b/roles/ckan/templates/ckan/db_restore.sh
@@ -48,7 +48,7 @@ error(){
   if [ -z "$SKIP_SLACK" ]; then
     slack_channel="sentry-stg" slack_notify "{{ application_namespace }} CKAN DB SQL restore" "RDS SQL dev DB restore has failed on: $1." "ERROR"
   fi
-  return 1
+  exit 1
 }
 
 get_s3_backup_vars(){


### PR DESCRIPTION
## Summary

Fixes two root causes that have prevented the nightly prod→dev sync from working for at least 6 months:

- **Backup was silently broken**: The backup CronJob used `postgres:13` (pg_dump v13.23) but the RDS instance runs PostgreSQL 14.22. pg_dump refused to connect, yet the script continued due to a bash `set -e` + `||` interaction — uploading **empty 0-byte dump files** to S3 every night and reporting success. Every file in `s3://dms-prod-backup/sql_backups/` back to at least 31 Dec 2025 is 0 bytes.
  - Fix: bump `ckan_backup_postgres_version` `13` → `14`
  - Fix: change `error()` in `db_backup.sh` and `db_restore.sh` from `return 1` to `exit 1` so failures actually abort the script

- **Restore CronJob was never deployed to dev**: `restore_production_backup` defaulted to `false`, so `restore-ckan-db` was never created in `dms-dev`. The deploy task already guards this with `fjelltopp_env_type != 'prod'`, so setting the default to `true` is safe.
  - Fix: set `restore_production_backup: true` as the default

## Background

Discovered while investigating why `dev.dms.hiv.health.gov.mw` had diverged from `dms.hiv.health.gov.mw`. A manual backup using `postgres:14` was run on 2026-06-29 and valid dumps now exist in S3 (16.9 MB ckan, 1.3 KB datastore).

## Test plan

- [ ] After merging, redeploy to `dms-prod` with Ansible — verify next nightly backup produces non-empty files in S3
- [ ] After merging, redeploy to `dms-dev` with Ansible — verify `restore-ckan-db` CronJob appears in the `dms-dev` namespace
- [ ] After the first successful nightly cycle, verify dev and prod data are in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)