### PR TITLE
fix: suspend backup/restore CronJobs, fix restore postgres image version

### DIFF
--- a/roles/ckan/templates/kubernetes/db_backup_cronjob.yaml
+++ b/roles/ckan/templates/kubernetes/db_backup_cronjob.yaml
@@ -14,6 +14,7 @@ metadata:
   name: backup-ckan-db
 spec:
   schedule: "17 2 * * *"
+  suspend: true
   jobTemplate:
     spec:
       template:

--- a/roles/ckan/templates/kubernetes/db_restore_cronjob.yaml
+++ b/roles/ckan/templates/kubernetes/db_restore_cronjob.yaml
@@ -14,6 +14,7 @@ metadata:
   name: restore-ckan-db
 spec:
   schedule: "17 5 * * *"
+  suspend: true
   jobTemplate:
     spec:
       template:
@@ -27,7 +28,7 @@ spec:
               - name: POSTGRES_PASSWORD
                 value: "{{ lookup('aws_secret', application_namespace + '_rds_admin_pw' , region = aws_region ) }}"
             name: ckan-db-restore
-            image: postgres:13
+            image: postgres:{{ ckan_backup_postgres_version }}
             command: ['bash', '-c']
             args:
               - bash /tmp/ckan_db_restore.sh


### PR DESCRIPTION
## Summary

The nightly prod→dev sync schedule is being moved to a GitHub Actions workflow (`dms-infrastructure` PR #25). The K8s CronJobs are kept as job templates so the workflow can use `kubectl create job --from=cronjob/...`, but suspended so they no longer auto-fire.

Also fixes a missed instance of the hardcoded `postgres:13` image in the restore CronJob initContainer — it now uses `{{ ckan_backup_postgres_version }}` consistently.

Note: suspending the CronJobs isn't the tidiest solution but it's the quickest way to get what we want: GHA oversight and control.

(Job's are ephemeral, we could port fully into GHA but that would require changing secrets / environment management fully, etc.)

## Changes

- `db_backup_cronjob.yaml`: add `suspend: true`
- `db_restore_cronjob.yaml`: add `suspend: true`, replace `postgres:13` with `{{ ckan_backup_postgres_version }}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)