### PR TITLE
fix: remove Slack notifications from backup and restore scripts

### DIFF
--- a/roles/ckan/templates/ckan/db_backup.sh
+++ b/roles/ckan/templates/ckan/db_backup.sh
@@ -10,7 +10,7 @@ date
 set -e
 
 apt update
-apt install awscli curl -y
+apt install awscli -y
 
 aws_cli=$(command -v aws)
 pgdump=$(command -v pg_dump)
@@ -23,30 +23,8 @@ DIR="${BASH_SOURCE%/*}"
 if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
 cd "${DIR}" || exit 1
 
-if [ -z "$slack_channel" ]; then
-  slack_channel="infrastructure"
-fi
-slack_webhook="{{ ckan_slack_webhook }}"
-# run with "Message title" "Message body" "Message status" parameters, where
-# "Message status" "ERROR" will print message in red block, otherwise it's green
-slack_notify(){
-  local color='good'
-  if [ "${3}" == 'ERROR' ]; then
-      color='danger'
-  fi
-  echo 'Sending to '${slack_channel}'...'
-  local message="payload={\"channel\": \"#${slack_channel}\",\"attachments\":[{\"pretext\":\"${1}\",\"text\":\"${2}\",\"color\":\"${color}\"}]}"
-  # set variable SKIP_SLACK if you don't want to send any Slack notifications
-  if [ -z "$SKIP_SLACK" ]; then
-    curl -X POST --data-urlencode "${message}" "${slack_webhook}"
-  fi
-}
-
 error(){
   echo "${1} did fail, check your permissions"
-  if [ -z "$SKIP_SLACK" ]; then
-    slack_channel="sentry-prod" slack_notify "{{ application_namespace }} CKAN DB SQL backup" "RDS SQL DB backup has failed on: $1." "ERROR"
-  fi
   exit 1
 }
 
@@ -76,9 +54,6 @@ create_backup(){
 }
 
 create_backup || error Create_backup
-if [ -z "$SKIP_SLACK" ]; then
-  slack_notify "{{ application_namespace }}CKAN DB SQL backup" "{{ application_namespace }} CKAN DB SQL backup has finished" "OK"
-fi
 echo "Time finished: "
 date
 

--- a/roles/ckan/templates/ckan/db_restore.sh
+++ b/roles/ckan/templates/ckan/db_restore.sh
@@ -10,7 +10,7 @@ date
 set -e
 
 apt update
-apt install awscli curl -y
+apt install awscli -y
 
 aws_cli=$(command -v aws)
 pgrestore=$(command -v pg_restore)
@@ -23,31 +23,8 @@ DIR="${BASH_SOURCE%/*}"
 if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
 cd "${DIR}" || exit 1
 
-if [ -z "$slack_channel" ]; then
-  slack_channel="infrastructure"
-fi
-slack_webhook="{{ ckan_slack_webhook }}"
-
-# run with "Message title" "Message body" "Message status" parameters, where
-# "Message status" "ERROR" will print message in red block, otherwise it's green
-slack_notify(){
-  local color='good'
-  if [ "${3}" == 'ERROR' ]; then
-      color='danger'
-  fi
-  echo 'Sending to '${slack_channel}'...'
-  local message="payload={\"channel\": \"#${slack_channel}\",\"attachments\":[{\"pretext\":\"${1}\",\"text\":\"${2}\",\"color\":\"${color}\"}]}"
-  # set variable SKIP_SLACK if you don't want to send any Slack notifications
-  if [ -z "$SKIP_SLACK" ]; then
-    curl -X POST --data-urlencode "${message}" "${slack_webhook}"
-  fi
-}
-
 error(){
   echo "${1} did fail, check your permissions"
-  if [ -z "$SKIP_SLACK" ]; then
-    slack_channel="sentry-stg" slack_notify "{{ application_namespace }} CKAN DB SQL restore" "RDS SQL dev DB restore has failed on: $1." "ERROR"
-  fi
   exit 1
 }
 
@@ -92,9 +69,6 @@ restore_backup(){
 }
 
 restore_backup || error restore_backup
-if [ -z "$SKIP_SLACK" ]; then
-  slack_notify "{{ application_namespace }} CKAN DB SQL restore" "{{ application_namespace }} CKAN DB SQL restore has finished" "OK"
-fi
 echo "Time finished: "
 date
 


### PR DESCRIPTION
## Summary

- Slack has been deprecated; removes all Slack notification code from `db_backup.sh` and `db_restore.sh`
- Removes `slack_notify`, `slack_webhook`, `slack_channel`, `SKIP_SLACK` checks, and the `curl` apt dependency
- Fixes a bug where the restore script would exit 1 on success because the success Slack curl failed against an unconfigured webhook

## Test plan

- [ ] Merge and tag a new release
- [ ] Bump submodule in dms-infrastructure and redeploy to dev
- [ ] Run the nightly sync workflow and confirm restore completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2E1AWqMHx7ZTyNuHRDsrc