### PR TITLE
fix: abort restore before dropdb if backup files are empty

### DIFF
--- a/roles/ckan/templates/ckan/db_restore.sh
+++ b/roles/ckan/templates/ckan/db_restore.sh
@@ -61,6 +61,8 @@ restore_backup(){
   fi
   copy_from_s3 "$DATE"-ckandb.sql.custom "$TEMP_BACKUP_LOCATION"/"$DATE"-ckandb.sql.custom ||  error "transferring CKAN sql backup"
   copy_from_s3 "$DATE"-datastoredb.sql.custom "$TEMP_BACKUP_LOCATION"/"$DATE"-datastoredb.sql.custom ||  error "transferring Datastore sql backup"
+  [ -s "$TEMP_BACKUP_LOCATION/$DATE-ckandb.sql.custom" ] || error "CKAN backup file is empty — aborting before drop"
+  [ -s "$TEMP_BACKUP_LOCATION/$DATE-datastoredb.sql.custom" ] || error "Datastore backup file is empty — aborting before drop"
   run_dbcleanup
   run_pgrestore "$TEMP_BACKUP_LOCATION"/"$DATE"-ckandb.sql.custom ckan ||  error "restoring CKAN DB sql backup"
   run_pgrestore "$TEMP_BACKUP_LOCATION"/"$DATE"-datastoredb.sql.custom datastore ||  error "restoring Datastore DB sql backup"


### PR DESCRIPTION
## Summary

- After downloading backup files from S3, checks both are non-empty before calling `run_dbcleanup`
- If either file is 0 bytes (e.g. due to a silent `pg_dump` failure), the script exits with an error and the live database is left untouched
- Companion to the workflow-level S3 size check in dms-infrastructure which blocks the restore job from starting at all when backup fails

## Test plan

- [ ] Merge and tag as v4.3.4
- [ ] Bump submodule in dms-infrastructure and deploy to both clusters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2E1AWqMHx7ZTyNuHRDsrc