### PR TITLE
fix: parameterise postgres image in ckandb_job templates

### DIFF
--- a/roles/ckan/templates/kubernetes/aks/ckandb_job.yaml
+++ b/roles/ckan/templates/kubernetes/aks/ckandb_job.yaml
@@ -27,7 +27,7 @@ spec:
             - name: POSTGRES_PASSWORD
               value: "{{ azure_db_admin_password }}"
           name: ckan-db-init
-          image: postgres:13
+          image: postgres:{{ ckan_backup_postgres_version }}
           command: ['bash', '-c']
           args:
             - bash /tmp/ckan_db_bootstrap.sh

--- a/roles/ckan/templates/kubernetes/ckandb_job.yaml
+++ b/roles/ckan/templates/kubernetes/ckandb_job.yaml
@@ -28,7 +28,7 @@ spec:
               value: "{{ ckan_rds_admin_pw }}"
 
           name: ckan-db-init
-          image: postgres:13
+          image: postgres:{{ ckan_backup_postgres_version }}
           command: ['bash', '-c']
           args:
             - bash /tmp/ckan_db_bootstrap.sh


### PR DESCRIPTION
## Summary

- `ckandb_job.yaml` (AWS) and `aks/ckandb_job.yaml` both hardcoded `postgres:13` for the DB init job
- The backup and restore CronJobs already use `{{ ckan_backup_postgres_version }}` (default: `14`, matching RDS 14)
- This change makes the DB init job consistent — all postgres containers in the CKAN role now use the same parameterised version

## Test plan

- [ ] `ckan_backup_postgres_version: 14` in `roles/ckan/defaults/main.yml` (already set — no change needed)
- [ ] Verify the DB init job renders `image: postgres:14` on next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)