### PR TITLE
feat: enable AWS Backup on EFS during cluster setup

### DIFF
--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -126,6 +126,15 @@
     msg: "No EFS found with tag Name={{ eks_cluster_name }}-efs. Ensure the EFS exists before running this role."
   when: efs_info.efs | length == 0
 
+- name: Enable AWS Backup on EFS
+  command: >
+    aws efs put-backup-policy
+    --region "{{ aws_region }}"
+    --file-system-id "{{ efs_info.efs[0].file_system_id }}"
+    --backup-policy Status=ENABLED
+  changed_when: false
+  become: false
+
 - name: Get EFS mount target ID
   command: >
     aws efs describe-mount-targets


### PR DESCRIPTION
## Summary

- The `ckan-storage` PVC (backed by EFS) was not covered by AWS Backup
- The `setup-eks-v2` role already looks up the EFS by name tag and has `file_system_id` available
- Adds an idempotent `aws efs put-backup-policy --backup-policy Status=ENABLED` step immediately after the EFS is confirmed to exist
- AWS Backup then manages daily snapshots with the account-default backup plan

## Test plan

- [ ] Re-run `setup_eks_v2.yml` after merge — step should succeed and show EFS backup policy as ENABLED in the AWS console
- [ ] No other tasks should be affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)