### PR TITLE
feat: add ckan-storage backup/restore CronJobs for nightly sync

### DIFF
--- a/roles/ckan/defaults/main.yml
+++ b/roles/ckan/defaults/main.yml
@@ -10,6 +10,7 @@ ckan_backup_access_secret: "dummyvalue"
 ckan_backup_s3: "dummyvalue"
 ckan_backup_sql_directory_s3: "dummyvalue"
 ckan_backup_postgres_version: 14
+ckan_awscli_image_tag: "2"
 ckan_debug_enabled: "false"
 
 fjelltopp_base_image: "fjelltopp/ubuntu:base"

--- a/roles/ckan/tasks/deploy.yml
+++ b/roles/ckan/tasks/deploy.yml
@@ -213,6 +213,7 @@
   when: fjelltopp_env_type == 'prod'
   with_items:
     - db_backup_cronjob.yaml
+    - storage_backup_cronjob.yaml
 
 - name: Setup db restore job
   kubernetes.core.k8s:
@@ -224,6 +225,7 @@
   when: fjelltopp_env_type != 'prod' and restore_production_backup
   with_items:
     - db_restore_cronjob.yaml
+    - storage_restore_cronjob.yaml
 
 - name: Check if CKAN returns 200 (20 tries, 60 sec interval)
   uri:

--- a/roles/ckan/tasks/deploy.yml
+++ b/roles/ckan/tasks/deploy.yml
@@ -215,7 +215,7 @@
     - db_backup_cronjob.yaml
     - storage_backup_cronjob.yaml
 
-- name: Setup db restore job
+- name: Setup restore jobs
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'templates/kubernetes/{{ item }}') | from_yaml_all|list }}"

--- a/roles/ckan/templates/ckan/db_backup.sh
+++ b/roles/ckan/templates/ckan/db_backup.sh
@@ -14,7 +14,8 @@ apt install awscli -y
 
 aws_cli=$(command -v aws)
 pgdump=$(command -v pg_dump)
-export AWS_REGION="eu-west-1"
+export AWS_REGION="{{ aws_region }}"
+export AWS_DEFAULT_REGION="{{ aws_region }}"
 export AWS_ACCESS_KEY_ID="{{ ckan_backup_access_key }}"
 export AWS_SECRET_ACCESS_KEY="{{ ckan_backup_access_secret }}"
 TEMP_BACKUP_LOCATION=/tmp/ckan_backup

--- a/roles/ckan/templates/ckan/storage_backup.sh
+++ b/roles/ckan/templates/ckan/storage_backup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export AWS_REGION="{{ aws_region }}"
+export AWS_ACCESS_KEY_ID="{{ ckan_backup_access_key }}"
+export AWS_SECRET_ACCESS_KEY="{{ ckan_backup_access_secret }}"
+
+echo "Time started: $(date -u)"
+echo "Syncing /var/lib/ckan/storage/ -> {{ ckan_backup_s3 }}/storage_backups/"
+aws s3 sync /var/lib/ckan/storage/ "{{ ckan_backup_s3 }}/storage_backups/" --delete
+echo "Time finished: $(date -u)"

--- a/roles/ckan/templates/ckan/storage_backup.sh
+++ b/roles/ckan/templates/ckan/storage_backup.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 export AWS_REGION="{{ aws_region }}"
+export AWS_DEFAULT_REGION="{{ aws_region }}"
 export AWS_ACCESS_KEY_ID="{{ ckan_backup_access_key }}"
 export AWS_SECRET_ACCESS_KEY="{{ ckan_backup_access_secret }}"
 

--- a/roles/ckan/templates/ckan/storage_backup.sh
+++ b/roles/ckan/templates/ckan/storage_backup.sh
@@ -6,6 +6,11 @@ export AWS_DEFAULT_REGION="{{ aws_region }}"
 export AWS_ACCESS_KEY_ID="{{ ckan_backup_access_key }}"
 export AWS_SECRET_ACCESS_KEY="{{ ckan_backup_access_secret }}"
 
+grep -q " /var/lib/ckan/storage " /proc/mounts || {
+  echo "ERROR: ckan-storage PVC is not mounted at /var/lib/ckan/storage — aborting to prevent wiping S3 backup"
+  exit 1
+}
+
 echo "Time started: $(date -u)"
 echo "Syncing /var/lib/ckan/storage/ -> {{ ckan_backup_s3 }}/storage_backups/"
 aws s3 sync /var/lib/ckan/storage/ "{{ ckan_backup_s3 }}/storage_backups/" --delete

--- a/roles/ckan/templates/ckan/storage_restore.sh
+++ b/roles/ckan/templates/ckan/storage_restore.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export AWS_REGION="{{ aws_region }}"
+export AWS_ACCESS_KEY_ID="{{ ckan_backup_access_key }}"
+export AWS_SECRET_ACCESS_KEY="{{ ckan_backup_access_secret }}"
+
+echo "Time started: $(date -u)"
+echo "Syncing {{ ckan_backup_s3 }}/storage_backups/ -> /var/lib/ckan/storage/"
+aws s3 sync "{{ ckan_backup_s3 }}/storage_backups/" /var/lib/ckan/storage/ --delete
+echo "Time finished: $(date -u)"

--- a/roles/ckan/templates/ckan/storage_restore.sh
+++ b/roles/ckan/templates/ckan/storage_restore.sh
@@ -6,6 +6,17 @@ export AWS_DEFAULT_REGION="{{ aws_region }}"
 export AWS_ACCESS_KEY_ID="{{ ckan_backup_access_key }}"
 export AWS_SECRET_ACCESS_KEY="{{ ckan_backup_access_secret }}"
 
+grep -q " /var/lib/ckan/storage " /proc/mounts || {
+  echo "ERROR: ckan-storage PVC is not mounted at /var/lib/ckan/storage — aborting"
+  exit 1
+}
+
+OBJECT_COUNT=$(aws s3 ls "{{ ckan_backup_s3 }}/storage_backups/" --recursive 2>/dev/null | wc -l)
+if [ "$OBJECT_COUNT" -eq 0 ]; then
+  echo "ERROR: S3 prefix storage_backups/ is empty — aborting to prevent wiping ckan-storage"
+  exit 1
+fi
+
 echo "Time started: $(date -u)"
 echo "Syncing {{ ckan_backup_s3 }}/storage_backups/ -> /var/lib/ckan/storage/"
 aws s3 sync "{{ ckan_backup_s3 }}/storage_backups/" /var/lib/ckan/storage/ --delete

--- a/roles/ckan/templates/ckan/storage_restore.sh
+++ b/roles/ckan/templates/ckan/storage_restore.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 export AWS_REGION="{{ aws_region }}"
+export AWS_DEFAULT_REGION="{{ aws_region }}"
 export AWS_ACCESS_KEY_ID="{{ ckan_backup_access_key }}"
 export AWS_SECRET_ACCESS_KEY="{{ ckan_backup_access_secret }}"
 

--- a/roles/ckan/templates/kubernetes/storage_backup_cronjob.yaml
+++ b/roles/ckan/templates/kubernetes/storage_backup_cronjob.yaml
@@ -21,7 +21,7 @@ spec:
         spec:
           containers:
           - name: ckan-storage-backup
-            image: amazon/aws-cli:latest
+            image: amazon/aws-cli:{{ ckan_awscli_image_tag }}
             command: ['bash', '-c']
             args:
               - bash /tmp/storage_backup.sh

--- a/roles/ckan/templates/kubernetes/storage_backup_cronjob.yaml
+++ b/roles/ckan/templates/kubernetes/storage_backup_cronjob.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ckan-storage-backup
+data:
+  storage_backup.sh: "{{ lookup('template', 'templates/ckan/storage_backup.sh') | b64encode }}"
+type: Opaque
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: backup-ckan-storage
+spec:
+  schedule: "17 2 * * *"
+  suspend: true
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: ckan-storage-backup
+            image: amazon/aws-cli:latest
+            command: ['bash', '-c']
+            args:
+              - bash /tmp/storage_backup.sh
+            volumeMounts:
+              - mountPath: /tmp/storage_backup.sh
+                name: ckan-storage-backup
+                readOnly: true
+                subPath: storage_backup.sh
+              - mountPath: /var/lib/ckan/storage
+                name: ckan-storage
+                readOnly: true
+          restartPolicy: Never
+          volumes:
+            - secret:
+                secretName: ckan-storage-backup
+              name: ckan-storage-backup
+            - name: ckan-storage
+              persistentVolumeClaim:
+                claimName: ckan-storage
+      backoffLimit: 1

--- a/roles/ckan/templates/kubernetes/storage_restore_cronjob.yaml
+++ b/roles/ckan/templates/kubernetes/storage_restore_cronjob.yaml
@@ -19,6 +19,8 @@ spec:
     spec:
       template:
         spec:
+          securityContext:
+            fsGroup: 900
           containers:
           - name: ckan-storage-restore
             image: amazon/aws-cli:latest

--- a/roles/ckan/templates/kubernetes/storage_restore_cronjob.yaml
+++ b/roles/ckan/templates/kubernetes/storage_restore_cronjob.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ckan-storage-restore
+data:
+  storage_restore.sh: "{{ lookup('template', 'templates/ckan/storage_restore.sh') | b64encode }}"
+type: Opaque
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: restore-ckan-storage
+spec:
+  schedule: "17 5 * * *"
+  suspend: true
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: ckan-storage-restore
+            image: amazon/aws-cli:latest
+            command: ['bash', '-c']
+            args:
+              - bash /tmp/storage_restore.sh
+            volumeMounts:
+              - mountPath: /tmp/storage_restore.sh
+                name: ckan-storage-restore
+                readOnly: true
+                subPath: storage_restore.sh
+              - mountPath: /var/lib/ckan/storage
+                name: ckan-storage
+          restartPolicy: Never
+          volumes:
+            - secret:
+                secretName: ckan-storage-restore
+              name: ckan-storage-restore
+            - name: ckan-storage
+              persistentVolumeClaim:
+                claimName: ckan-storage
+      backoffLimit: 1

--- a/roles/ckan/templates/kubernetes/storage_restore_cronjob.yaml
+++ b/roles/ckan/templates/kubernetes/storage_restore_cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             fsGroup: 900
           containers:
           - name: ckan-storage-restore
-            image: amazon/aws-cli:latest
+            image: amazon/aws-cli:{{ ckan_awscli_image_tag }}
             command: ['bash', '-c']
             args:
               - bash /tmp/storage_restore.sh


### PR DESCRIPTION
## Summary

- Adds `backup-ckan-storage` CronJob (deployed to prod) that syncs `/var/lib/ckan/storage/` → `s3://dms-prod-backup/storage_backups/` using `aws s3 sync --delete`
- Adds `restore-ckan-storage` CronJob (deployed to dev) that syncs `s3://dms-prod-backup/storage_backups/` → `/var/lib/ckan/storage/` using `aws s3 sync --delete`
- Both are deployed `suspend: true`; the nightly `sync-prod-to-dev.yml` workflow will trigger them via `kubectl create job --from=cronjob` (see companion dms-infrastructure PR)
- Uses amazon/aws-cli:{{ ckan_awscli_image_tag }} image (defaults to 2, pinning to AWS CLI v2.x — no apt install needed, unlike the DB backup script); override ckan_awscli_image_tag in inventory for a tighter pin (e.g. 2.27.44)
- `aws_region` is templated from `{{ aws_region }}` — avoids the pre-existing `eu-west-1` hardcode in `db_backup.sh`
- Wired into `deploy.yml` alongside `db_backup_cronjob.yaml` (prod) and `db_restore_cronjob.yaml` (dev)

## Contents of ckan-storage

User profile images, org/group/page icons — small files, fast to sync.

## Test plan

- [ ] Deploy to prod — verify `backup-ckan-storage` CronJob appears in `dms-prod` namespace
- [ ] Deploy to dev — verify `restore-ckan-storage` CronJob appears in `dms-dev` namespace
- [ ] Manually trigger: `kubectl create job --from=cronjob/backup-ckan-storage test-backup -n dms-prod`; check S3 for `storage_backups/` prefix
- [ ] Manually trigger restore; verify files appear in dev ckan-storage PVC

🤖 Generated with [Claude Code](https://claude.com/claude-code)