### PR TITLE
fix: change ckan_awscli_image_tag default to 'latest'

### DIFF
--- a/roles/ckan/defaults/main.yml
+++ b/roles/ckan/defaults/main.yml
@@ -10,7 +10,7 @@ ckan_backup_access_secret: "dummyvalue"
 ckan_backup_s3: "dummyvalue"
 ckan_backup_sql_directory_s3: "dummyvalue"
 ckan_backup_postgres_version: 14
-ckan_awscli_image_tag: "2"
+ckan_awscli_image_tag: "latest"
 ckan_debug_enabled: "false"
 
 fjelltopp_base_image: "fjelltopp/ubuntu:base"


### PR DESCRIPTION
## Summary

`amazon/aws-cli:2` does not exist as a Docker Hub tag — the image only publishes `latest` and full semver tags (e.g. `2.27.44`). The storage backup/restore CronJobs were going into `ImagePullBackOff` immediately on first run.

Fixes the default from `"2"` → `"latest"`. Inventory-level overrides to a specific semver tag (e.g. `2.27.44`) are still supported via `ckan_awscli_image_tag`.

## Test plan

- [ ] Verify storage backup CronJob pod starts successfully after Ansible redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)