### PR TITLE
feat: deploy Cluster Autoscaler for the ckan-v2 node group

### DIFF
--- a/eksctl/cluster-config.yaml
+++ b/eksctl/cluster-config.yaml
@@ -21,6 +21,15 @@ managedNodeGroups:
     maxSize: 3
     desiredCapacity: 1
     amiFamily: AmazonLinux2023
+    # eksctl auto-tags the backing ASG with k8s.io/cluster-autoscaler/enabled
+    # and k8s.io/cluster-autoscaler/<cluster-name>=owned on creation, which
+    # Cluster Autoscaler (deployed by the ckan role) relies on for
+    # auto-discovery. If this node group is ever recreated, the node role
+    # also needs the ckan-v2-cluster-autoscaler IAM policy re-attached —
+    # done manually, not via withAddonPolicies, since eksctl's built-in
+    # `autoScaler: true` shorthand grants unscoped SetDesiredCapacity/
+    # TerminateInstanceInAutoScalingGroup on *any* ASG; the policy actually
+    # attached is scoped to ASGs tagged k8s.io/cluster-autoscaler/<cluster>=owned.
     iam:
       withAddonPolicies:
         cloudWatch: true

--- a/eksctl/cluster-config.yaml
+++ b/eksctl/cluster-config.yaml
@@ -24,16 +24,17 @@ managedNodeGroups:
     # eksctl auto-tags the backing ASG with k8s.io/cluster-autoscaler/enabled
     # and k8s.io/cluster-autoscaler/<cluster-name>=owned on creation, which
     # Cluster Autoscaler (deployed by the ckan role) relies on for
-    # auto-discovery. If this node group is ever recreated, the node role
-    # also needs the ckan-v2-cluster-autoscaler IAM policy re-attached —
-    # done manually, not via withAddonPolicies, since eksctl's built-in
-    # `autoScaler: true` shorthand grants unscoped SetDesiredCapacity/
-    # TerminateInstanceInAutoScalingGroup on *any* ASG; the policy actually
-    # attached is scoped to ASGs tagged k8s.io/cluster-autoscaler/<cluster>=owned.
+    # auto-discovery. attachPolicyARNs (below) is used instead of eksctl's
+    # `autoScaler: true` addon-policy shorthand since that grants unscoped
+    # SetDesiredCapacity/TerminateInstanceInAutoScalingGroup on *any* ASG —
+    # ckan-v2-cluster-autoscaler scopes those to ASGs tagged
+    # k8s.io/cluster-autoscaler/<cluster>=owned.
     iam:
       withAddonPolicies:
         cloudWatch: true
         efs: true
+      attachPolicyARNs:
+        - arn:aws:iam::074027416471:policy/ckan-v2-cluster-autoscaler
 
 addons:
   # version: latest resolves at provision time to the newest version compatible

--- a/roles/ckan/defaults/main.yml
+++ b/roles/ckan/defaults/main.yml
@@ -12,6 +12,11 @@ ckan_uwsgi_threads: 2
 ckan_ingress_limit_rps: ""
 ckan_ingress_limit_connections: 20
 
+# Cluster Autoscaler, deployed once per EKS cluster (skipped for local/
+# minikube). Version tracks the cluster's k8s minor version — see
+# https://github.com/kubernetes/autoscaler/releases for compatible tags.
+cluster_autoscaler_image_tag: "v1.36.0"
+
 ckan_slack_webhook: "dummyvalue"
 ckan_backup_bucket_name: "dummyvalue"
 ckan_backup_access_key: "dummyvalue"

--- a/roles/ckan/tasks/deploy.yml
+++ b/roles/ckan/tasks/deploy.yml
@@ -43,11 +43,10 @@
   when: ckan_tls_name is defined
 
 # Cluster-wide (one per EKS cluster, not per app namespace) — idempotent to
-# re-apply from every environment's deploy. Requires the ckan-workers node
-# role to already have the ckan-v2-cluster-autoscaler IAM policy attached
-# (done once, out of band — see fjelltopp-ansible#<PR> for the policy JSON);
-# the ASG is auto-discovered via tags eksctl already sets on node group
-# creation (k8s.io/cluster-autoscaler/enabled, k8s.io/cluster-autoscaler/<cluster>).
+# re-apply from every environment's deploy. Requires the node role IAM
+# policy declared in eksctl/cluster-config.yaml (iam.attachPolicyARNs); the
+# ASG is auto-discovered via tags eksctl already sets on node group creation
+# (k8s.io/cluster-autoscaler/enabled, k8s.io/cluster-autoscaler/<cluster>).
 - name: Deploy Cluster Autoscaler
   kubernetes.core.k8s:
     state: present

--- a/roles/ckan/tasks/deploy.yml
+++ b/roles/ckan/tasks/deploy.yml
@@ -42,6 +42,22 @@
     - nginx-ingress-tls-elb_v1_0_0.yaml
   when: ckan_tls_name is defined
 
+# Cluster-wide (one per EKS cluster, not per app namespace) — idempotent to
+# re-apply from every environment's deploy. Requires the ckan-workers node
+# role to already have the ckan-v2-cluster-autoscaler IAM policy attached
+# (done once, out of band — see fjelltopp-ansible#<PR> for the policy JSON);
+# the ASG is auto-discovered via tags eksctl already sets on node group
+# creation (k8s.io/cluster-autoscaler/enabled, k8s.io/cluster-autoscaler/<cluster>).
+- name: Deploy Cluster Autoscaler
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'templates/kubernetes/{{ item }}') | from_yaml_all|list }}"
+    kubeconfig: "{{ kubeconfig }}"
+  become: false
+  with_items:
+    - cluster-autoscaler.yaml
+  when: fjelltopp_env_type != 'local'
+
 - name: Patch Minikube ingress
   kubernetes.core.k8s:
     state: patched

--- a/roles/ckan/templates/kubernetes/cluster-autoscaler.yaml
+++ b/roles/ckan/templates/kubernetes/cluster-autoscaler.yaml
@@ -154,7 +154,7 @@ spec:
             - --skip-nodes-with-system-pods=false
             - --balance-similar-node-groups
             - --expander=least-waste
-            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/{{ eks_cluster_name }}
+            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/{{ eks_cluster_name_v2 }}
           env:
             - name: AWS_REGION
               value: "{{ aws_region }}"

--- a/roles/ckan/templates/kubernetes/cluster-autoscaler.yaml
+++ b/roles/ckan/templates/kubernetes/cluster-autoscaler.yaml
@@ -1,0 +1,169 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-app: cluster-autoscaler
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-app: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["events", "endpoints"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    resourceNames: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["watch", "list", "get", "update"]
+  - apiGroups: [""]
+    resources:
+      - "namespaces"
+      - "pods"
+      - "services"
+      - "replicationcontrollers"
+      - "persistentvolumeclaims"
+      - "persistentvolumes"
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities", "volumeattachments"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["resource.k8s.io"]
+    resources: ["resourceslices", "deviceclasses", "resourceclaims"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["batch", "extensions"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resourceNames: ["cluster-autoscaler"]
+    resources: ["leases"]
+    verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-app: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
+    verbs: ["delete", "get", "update", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    app: cluster-autoscaler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  template:
+    metadata:
+      labels:
+        app: cluster-autoscaler
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8085"
+    spec:
+      # Runs as the node instance role (no IRSA/OIDC provider set up for this
+      # cluster) — see the ckan-v2-cluster-autoscaler IAM policy, attached
+      # directly to the ckan-workers node role, mutating actions scoped to
+      # ASGs tagged k8s.io/cluster-autoscaler/<cluster>=owned.
+      serviceAccountName: cluster-autoscaler
+      containers:
+        - image: "registry.k8s.io/autoscaling/cluster-autoscaler:{{ cluster_autoscaler_image_tag }}"
+          name: cluster-autoscaler
+          resources:
+            requests:
+              cpu: 100m
+              memory: 300Mi
+            limits:
+              memory: 300Mi
+          command:
+            - ./cluster-autoscaler
+            - --v=4
+            - --stderrthreshold=info
+            - --cloud-provider=aws
+            - --skip-nodes-with-local-storage=false
+            - --skip-nodes-with-system-pods=false
+            - --balance-similar-node-groups
+            - --expander=least-waste
+            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/{{ eks_cluster_name }}
+          env:
+            - name: AWS_REGION
+              value: "{{ aws_region }}"
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              readOnly: true
+          imagePullPolicy: Always
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: /etc/ssl/certs/ca-bundle.crt

--- a/roles/ckan/templates/kubernetes/cluster-autoscaler.yaml
+++ b/roles/ckan/templates/kubernetes/cluster-autoscaler.yaml
@@ -168,3 +168,4 @@ spec:
         - name: ssl-certs
           hostPath:
             path: /etc/ssl/certs/ca-bundle.crt
+            type: File

--- a/roles/ckan/templates/kubernetes/cluster-autoscaler.yaml
+++ b/roles/ckan/templates/kubernetes/cluster-autoscaler.yaml
@@ -136,6 +136,7 @@ spec:
       # directly to the ckan-workers node role, mutating actions scoped to
       # ASGs tagged k8s.io/cluster-autoscaler/<cluster>=owned.
       serviceAccountName: cluster-autoscaler
+      priorityClassName: system-cluster-critical
       containers:
         - image: "registry.k8s.io/autoscaling/cluster-autoscaler:{{ cluster_autoscaler_image_tag }}"
           name: cluster-autoscaler


### PR DESCRIPTION
## Summary
Adds Cluster Autoscaler to the `ckan-v2` cluster's `ckan-workers` node group (min 1 / max 3 / desired 1), so capacity grows automatically when a pod can't schedule and shrinks back down when idle — rather than either living with the scheduling squeeze indefinitely or paying for a permanently-idle 2nd node.

## Why
The prod restart-loop investigation (#85) traced a secondary issue: `ckan-workers`' ASG has real headroom (max 3) but sits at a single node, because `desiredCapacity` was never reconciled from the declared eksctl config after initial creation. A rolling update needs the old and new pod to briefly coexist (`maxUnavailable: 0`), and with zero spare capacity that hits `FailedScheduling: Insufficient cpu` — this is exactly what happened deploying the #85 fix to prod, and again while testing this PR against dev.

## Change
- `roles/ckan/templates/kubernetes/cluster-autoscaler.yaml` — standard upstream manifest (ServiceAccount, RBAC, Deployment), templated for cluster name/region
- `roles/ckan/tasks/deploy.yml` — new idempotent deploy task, cluster-wide (not per-namespace), skipped for local/minikube envs
- `roles/ckan/defaults/main.yml` — `cluster_autoscaler_image_tag` default (`v1.36.0`, matches the cluster's k8s minor version)
- `eksctl/cluster-config.yaml` — documents the out-of-band IAM policy attachment for reproducibility if the node group is ever recreated

**IAM**: runs under the node instance role (no OIDC/IRSA set up on this cluster yet, so this matches how the existing `cloudWatch`/`efs` addon policies already work). A policy (`ckan-v2-cluster-autoscaler`) was created and attached to the node role out of band — its `Describe*` actions are unscoped (read-only), but anything that actually changes capacity (`SetDesiredCapacity`, `TerminateInstanceInAutoScalingGroup`, `UpdateAutoScalingGroup`) is conditioned on `aws:ResourceTag/k8s.io/cluster-autoscaler/ckan-v2 = owned` — which eksctl already tags `ckan-workers` with, and nothing else in the account carries. Deliberately not using eksctl's built-in `withAddonPolicies.autoScaler: true` shorthand since that grants those same mutating actions unscoped across *any* ASG in the account.

## Test plan
- [x] Validated live end-to-end on `ckan-v2`: forced a rollout restart on `dms-dev` while the shared node sat at 90% CPU requested. New pod went `Pending` (`FailedScheduling: Insufficient cpu`) → autoscaler logged `TriggeredScaleUp: [...] 1->2 (max: 3)` within seconds → new node `Ready` in ~80s → pod scheduled, became `1/1 Running` → old pod terminated cleanly. Zero downtime, dev site returned `200` throughout.
- [x] Confirmed RBAC is clean — no forbidden/error log lines after adding the `resource.k8s.io` (DRA) and `storage.k8s.io/volumeattachments` rules the base upstream ClusterRole was missing for this k8s version
- [ ] Since this is cluster-wide, re-running the `dms_prod` deploy will also pick this up (idempotent — no behavior change for prod beyond having the autoscaler available)