### PR TITLE
fix: add PodDisruptionBudget to protect the single ckan replica

### DIFF
--- a/roles/ckan/templates/kubernetes/ckan.yaml
+++ b/roles/ckan/templates/kubernetes/ckan.yaml
@@ -258,3 +258,21 @@ spec:
 status:
   loadBalancer: {}
 {% endif %}
+
+---
+# Protects the single ckan replica from voluntary disruption (cluster
+# autoscaler scale-down, kubectl drain) — without this, scaling a node
+# down evicts the sole pod with no replacement ready, causing a real
+# user-facing gap (nginx has zero backends) until it reschedules and
+# starts elsewhere. Deployment rolling updates are unaffected: they
+# replace pods directly via the ReplicaSet controller, not the Eviction
+# API this budget governs.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: ckan
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: ckan

--- a/roles/ckan/templates/kubernetes/ckan.yaml
+++ b/roles/ckan/templates/kubernetes/ckan.yaml
@@ -260,13 +260,8 @@ status:
 {% endif %}
 
 ---
-# Protects the single ckan replica from voluntary disruption (cluster
-# autoscaler scale-down, kubectl drain) — without this, scaling a node
-# down evicts the sole pod with no replacement ready, causing a real
-# user-facing gap (nginx has zero backends) until it reschedules and
-# starts elsewhere. Deployment rolling updates are unaffected: they
-# replace pods directly via the ReplicaSet controller, not the Eviction
-# API this budget governs.
+# Stops the autoscaler/drain from evicting the sole ckan pod. Doesn't
+# affect Deployment rolling updates (those don't go through Eviction).
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
## Summary
Adds a `PodDisruptionBudget` (`minAvailable: 1`) for `ckan` to `ckan.yaml`, applied for both `dms-dev` and `dms-prod`.

## Why — live incident
Rolling out v2.4.2 to prod worked correctly (autoscaler scaled 1→2 nodes to fit old+new pod during the rollout, zero downtime there). But once the rollout finished and cluster-autoscaler scaled the now-idle spare node back down, it evicted the **sole** `ckan` pod (`ckan_pod_replicas_nr: 1`) with nothing protecting it — nginx had zero backends for the service for ~2-3 minutes until the pod rescheduled and became ready on the remaining node. Confirmed via ingress-nginx logs: every request during that window returned `503` with `upstream_addr: -`.

This is #86 (Cluster Autoscaler) interacting with the pre-existing single-replica deployment — the scale-up path was already safe (`maxUnavailable: 0` on the Deployment), but nothing guarded the scale-*down* path against evicting the last live replica.

## Fix
`minAvailable: 1` makes cluster-autoscaler (and `kubectl drain`) skip a node hosting the last `ckan` pod for scale-down, rather than evicting it outright — it'll wait until it's safe (e.g. after a real second replica exists, or never, given replicas: 1). Deployment rolling updates are unaffected: they replace pods directly via the ReplicaSet controller, not the Eviction API a PDB governs, so normal deploys keep working exactly as they do today.

## Test plan
- [x] Applied live to `dms-prod` and `dms-dev` immediately (active incident) — `kubectl get pdb` confirms `MIN AVAILABLE: 1` on both
- [x] Confirmed prod is healthy again post-incident: pod `1/1 Running`, site `200`, and the resource-download fix (#41/#95/#46) verified working end-to-end