### PR TITLE
fix: match AWS's actual wording for existing EKS access entries

### DIFF
--- a/roles/setup-eks-v2/tasks/main.yml
+++ b/roles/setup-eks-v2/tasks/main.yml
@@ -217,7 +217,7 @@
     --principal-arn "arn:aws:iam::{{ aws_account_id }}:role/github-actions"
   register: access_entry_result
   changed_when: access_entry_result.rc == 0
-  failed_when: access_entry_result.rc != 0 and not ('resourceinuseexception' in (access_entry_result.stderr | lower) and 'already exists' in (access_entry_result.stderr | lower))
+  failed_when: access_entry_result.rc != 0 and not ('resourceinuseexception' in (access_entry_result.stderr | lower) and ('already exists' in (access_entry_result.stderr | lower) or 'already in use' in (access_entry_result.stderr | lower)))
   become: false
 
 - name: Associate cluster-admin policy with github-actions access entry


### PR DESCRIPTION
## Summary
Fixes the `failed_when` guard on "Grant github-actions role EKS access entry" to also tolerate AWS's actual error wording for an already-existing access entry.

## Why
Running `setup-eks-v2` against `dms_prod`'s inventory for the first time (now possible after fjelltopp/dms-infrastructure#47 parameterized the previously dev-hardcoded workflow) failed here:

```
An error occurred (ResourceInUseException) when calling the CreateAccessEntry
operation: The specified access entry resource is already in use on this cluster.
```

The existing guard checked for `'already exists'`, but AWS's real message says `'already in use'` — different wording, so the tolerance never matched. `ckan-v2` is a cluster shared by both dev and prod, so this access entry was already created the first time this task ran (for dev); prod's run correctly hit the same one and should have treated it as benign, but failed instead.

## Test plan
- [ ] Re-run "Setup EKS v2" with `inventory=dms_prod`, confirm this task now passes and the rest of the role (including the Giftless S3 bucket policy reconciliation this whole exercise was for) completes